### PR TITLE
Add kernelmajversion ubuntu fact

### DIFF
--- a/lib/facts/ubuntu/kernelmajversion.rb
+++ b/lib/facts/ubuntu/kernelmajversion.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class Kernelmajversion
+      FACT_NAME = 'kernelmajversion'
+
+      def call_the_resolver
+        full_version = Resolvers::Uname.resolve(:kernelrelease)
+
+        ResolvedFact.new(FACT_NAME, major_version(full_version))
+      end
+
+      private
+
+      def major_version(full_version)
+        versions_split = full_version.split('.')
+        return versions_split[0] if versions_split.length <= 1
+
+        versions_split[0] + '.' + versions_split[1]
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/kernelmajversion_spec.rb
+++ b/spec/facter/facts/ubuntu/kernelmajversion_spec.rb
@@ -1,16 +1,28 @@
 # frozen_string_literal: true
 
 describe 'Ubuntu Kernelmajversion' do
-  context '#call_the_resolver' do
-    let(:value) { '4.15' }
-
-    it 'returns a fact' do
+  shared_examples 'kernelmajversion fact expectation' do
+    it 'returns the correct major version' do
       expected_fact = double(Facter::ResolvedFact, name: 'kernelmajversion', value: value)
       allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelrelease).and_return(value)
       allow(Facter::ResolvedFact).to receive(:new).with('kernelmajversion', value).and_return(expected_fact)
 
       fact = Facter::Ubuntu::Kernelmajversion.new
       expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+
+  describe '#call_the_resolver' do
+    context 'when full version is separated by . delimeter' do
+      let(:value) { '4.15' }
+
+      include_examples 'kernelmajversion fact expectation'
+    end
+
+    context 'when full version does not have a . delimeter' do
+      let(:value) { '4test' }
+
+      include_examples 'kernelmajversion fact expectation'
     end
   end
 end

--- a/spec/facter/facts/ubuntu/kernelmajversion_spec.rb
+++ b/spec/facter/facts/ubuntu/kernelmajversion_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu Kernelmajversion' do
+  context '#call_the_resolver' do
+    let(:value) { '4.15' }
+
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'kernelmajversion', value: value)
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:kernelrelease).and_return(value)
+      allow(Facter::ResolvedFact).to receive(:new).with('kernelmajversion', value).and_return(expected_fact)
+
+      fact = Facter::Ubuntu::Kernelmajversion.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
#75

uname -r returns the release but uname -v doesn't , that's why i used `:kernelrelease` instead of `:kerneversion` param

![Screenshot from 2019-10-09 12-09-28](https://user-images.githubusercontent.com/8425834/66476511-ae798a80-ea8d-11e9-8ff7-8f003f266624.png)

![Screenshot from 2019-10-09 12-04-21](https://user-images.githubusercontent.com/8425834/66476472-97d33380-ea8d-11e9-8329-e753ec99b772.png)
