### PR TITLE
Add Ubuntu memory swap capacity fact

### DIFF
--- a/lib/facts/ubuntu/memory/swap/capacity.rb
+++ b/lib/facts/ubuntu/memory/swap/capacity.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class MemorySwapCapacity
+      FACT_NAME = 'memory.swap.capacity'
+
+      def call_the_resolver
+        fact_value = Resolvers::Linux::Memory.resolve(:swap_capacity)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/memory/swap/capacity_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/capacity_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu MemorySwapCapacity' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.capacity', value: 2048)
+      allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_capacity).and_return(2048)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.capacity', 2048).and_return(expected_fact)
+
+      fact = Facter::Ubuntu::MemorySwapCapacity.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
[Issue_117](https://github.com/puppetlabs/facter-ng/issues/117)

### Why
- We still don't have the fact for Ubuntu memory swap capacity

### How
- Add the fact and the test coverage for this new implementation