### PR TITLE
Add memory swap available bytes for Ubuntu

### DIFF
--- a/lib/facts/ubuntu/memory/swap/available_bytes.rb
+++ b/lib/facts/ubuntu/memory/swap/available_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class MemorySwapAvailableBytes
+      FACT_NAME = 'memory.swap.available_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Linux::Memory.resolve(:swap_free)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/available_bytes_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu MemorySwapAvailableBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available_bytes', value: 3072)
+      allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_free).and_return(3072)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available_bytes', 3072).and_return(expected_fact)
+
+      fact = Facter::Ubuntu::MemorySwapAvailableBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
[Issue_116](https://github.com/puppetlabs/facter-ng/issues/116)

### Why
- We still don't have the fact for Ubuntu memory swap available bytes

### How
- Add the fact and the test coverage for this new implementation