### PR TITLE
Add Ubuntu memory.swap.available fact

### DIFF
--- a/lib/facts/ubuntu/memory/swap/available.rb
+++ b/lib/facts/ubuntu/memory/swap/available.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class MemorySwapAvailable
+      FACT_NAME = 'memory.swap.available'
+
+      def call_the_resolver
+        fact_value = Resolvers::Linux::Memory.resolve(:swap_free)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/memory/swap/available_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/available_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu MemorySwapAvailable' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: '1.0 KiB')
+      allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_free).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', '1.0 KiB').and_return(expected_fact)
+
+      fact = Facter::Ubuntu::MemorySwapAvailable.new
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
This implements the memory.swap.available fact on Ubuntu.

Fixes #115 