### PR TITLE
Add Ubuntu memory.swap.used_bytes fact

### DIFF
--- a/lib/facts/ubuntu/memory/swap/used_bytes.rb
+++ b/lib/facts/ubuntu/memory/swap/used_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class MemorySwapUsedBytes
+      FACT_NAME = 'memory.swap.used_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Linux::Memory.resolve(:swap_used_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/memory/swap/used_bytes_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/used_bytes_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu MemorySwapUsedBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used_bytes', value: 'value')
+      allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_used_bytes).and_return('value')
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used_bytes', 'value').and_return(expected_fact)
+
+      fact = Facter::Ubuntu::MemorySwapUsedBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
This implements the memory.swap.used_bytes fact on Ubuntu.

Fixes #125 