### PR TITLE
Add Ubuntu memory.swap.used fact

### DIFF
--- a/lib/facts/ubuntu/memory/swap/used.rb
+++ b/lib/facts/ubuntu/memory/swap/used.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facter
+  module Ubuntu
+    class MemorySwapUsed
+      FACT_NAME = 'memory.swap.used'
+
+      def call_the_resolver
+        fact_value = Resolvers::Linux::Memory.resolve(:swap_used_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/spec/facter/facts/ubuntu/memory/swap/used_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/used_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Ubuntu MemorySwapUsed' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used', value: '1.0 KiB')
+      allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used', '1.0 KiB').and_return(expected_fact)
+
+      fact = Facter::Ubuntu::MemorySwapUsed.new
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end


### PR DESCRIPTION
Implements the memory.swap.used fact for Ubuntu.

Fixes #124 