### PR TITLE
(FACT-2246) Create mountpoints resolver

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 25
   Exclude:
     - 'lib/custom_facts/util/values.rb'
     - 'lib/custom_facts/util/confine.rb'
@@ -23,6 +23,7 @@ Naming/ClassAndModuleCamelCase:
     - 'spec/mocks/**/*'
 
 Metrics/AbcSize:
+  Max: 30
   Exclude:
     - 'spec/custom_facts/util/parser_spec.rb'
     - 'spec/custom_facts/core/logging_spec.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 20
   Exclude:
     - 'lib/custom_facts/util/values.rb'
     - 'lib/custom_facts/util/confine.rb'
@@ -23,7 +23,6 @@ Naming/ClassAndModuleCamelCase:
     - 'spec/mocks/**/*'
 
 Metrics/AbcSize:
-  Max: 30
   Exclude:
     - 'spec/custom_facts/util/parser_spec.rb'
     - 'spec/custom_facts/core/logging_spec.rb'

--- a/facter-ng.gemspec
+++ b/facter-ng.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
-  spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.74.0'

--- a/facter-ng.gemspec
+++ b/facter-ng.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
+  spec.add_development_dependency 'pry-byebug', '~> 3.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.74.0'
@@ -39,5 +40,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'bundler', '~> 2.0'
   spec.add_runtime_dependency 'hocon', '1.3.0'
+  spec.add_runtime_dependency 'sys-filesystem', '~> 1.3'
   spec.add_runtime_dependency 'thor', '~> 1.0.1'
 end

--- a/lib/facts/fedora/mountpoints.rb
+++ b/lib/facts/fedora/mountpoints.rb
@@ -10,7 +10,7 @@ module Facter
 
         fact = {}
         mountpoints.each do |mnt|
-          fact[mnt[:path]] = mnt.reject { |k| k == :path }
+          fact[mnt[:path].to_sym] = mnt.reject { |k| k == :path }
         end
 
         ResolvedFact.new(FACT_NAME, fact)

--- a/lib/facts/fedora/mountpoints.rb
+++ b/lib/facts/fedora/mountpoints.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Facter
+  module Fedora
+    class Mountpoints
+      FACT_NAME = 'mountpoints'
+
+      def call_the_resolver
+        mountpoints = Resolvers::Linux::Mountpoints.resolve(FACT_NAME.to_sym)
+
+        fact = {}
+        mountpoints.each do |mnt|
+          fact[mnt[:path]] = mnt.reject { |k| k == :path }
+        end
+
+        ResolvedFact.new(FACT_NAME, fact)
+      end
+    end
+  end
+end

--- a/lib/facts_utils/bytes_to_human_readable.rb
+++ b/lib/facts_utils/bytes_to_human_readable.rb
@@ -11,10 +11,17 @@ module Facter
         result = determine_exponent(bytes)
         return bytes.to_s + ' bytes' if result[:exp] > units.size
 
-        result[:converted_number].to_s + " #{units[result[:exp] - 1]}iB"
+        converted_number = pad_number(result[:converted_number])
+        converted_number + " #{units[result[:exp] - 1]}iB"
       end
 
       private
+
+      def pad_number(number)
+        number = number.to_s
+        number << '0' if number.split('.').last.length == 1
+        number
+      end
 
       def determine_exponent(bytes)
         exp = (Math.log2(bytes) / 10.0).floor

--- a/lib/resolvers/mountpoints_resolver.rb
+++ b/lib/resolvers/mountpoints_resolver.rb
@@ -6,7 +6,7 @@ module Facter
       class Mountpoints < BaseResolver
         @semaphore = Mutex.new
         @fact_list ||= {}
-        @log = Facter::Log.new
+        @log = Facter::Log.new(self)
         class << self
           def resolve(fact_name)
             @semaphore.synchronize do
@@ -45,7 +45,7 @@ module Facter
             device
           end
 
-          def read_mounts
+          def read_mounts # rubocop:disable Metrics/AbcSize
             require 'sys/filesystem'
             mounts = []
             Sys::Filesystem.mounts do |fs|

--- a/lib/resolvers/mountpoints_resolver.rb
+++ b/lib/resolvers/mountpoints_resolver.rb
@@ -54,8 +54,7 @@ module Facter
               path = fs.mount_point
               options = fs.options.split(',')
 
-              next if path =~ %r{^/(proc|sys)} && filesystem != 'tmpfs'
-              next if filesystem == 'autofs'
+              next if path =~ %r{^/(proc|sys)} && filesystem != 'tmpfs' || filesystem == 'autofs'
 
               stats = Sys::Filesystem.stat(path)
               size_bytes = stats.bytes_total

--- a/lib/resolvers/mountpoints_resolver.rb
+++ b/lib/resolvers/mountpoints_resolver.rb
@@ -28,10 +28,10 @@ module Facter
             match&.captures&.first
           end
 
-          def compute_capacity(used, available, total)
-            if used == available
+          def compute_capacity(used, total)
+            if used == total
               '100%'
-            elsif used.positive? && total.positive?
+            elsif used.positive?
               "#{format('%.2f', 100.0 * used.to_f / total.to_f)}%"
             else
               '0%'
@@ -62,7 +62,7 @@ module Facter
 
               used_bytes = stats.bytes_used
               total_bytes = used_bytes + available_bytes
-              capacity = compute_capacity(used_bytes, available_bytes, total_bytes)
+              capacity = compute_capacity(used_bytes, total_bytes)
 
               size = Facter::BytesToHumanReadable.convert(size_bytes)
               available = Facter::BytesToHumanReadable.convert(available_bytes)

--- a/lib/resolvers/mountpoints_resolver.rb
+++ b/lib/resolvers/mountpoints_resolver.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Linux
+      class Mountpoints < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        @log = Facter::Log.new
+        class << self
+          def resolve(fact_name)
+            @semaphore.synchronize do
+              result ||= @fact_list[fact_name]
+              subscribe_to_manager
+              result || read_mounts
+            end
+          end
+
+          private
+
+          MOUNT_KEYS = %i[device filesystem path options
+                          available available_bytes size
+                          size_bytes used used_bytes capacity].freeze
+
+          def root_device
+            cmdline = File.read('/proc/cmdline')
+            match = cmdline.match(/root=([^\\s]+)/)
+            match&.captures&.first
+          end
+
+          def compute_capacity(used, available, total)
+            if used == available
+              '100%'
+            elsif used.positive? && total.positive?
+              "#{format('%.2f', 100.0 * used.to_f / total.to_f)}%"
+            else
+              '0%'
+            end
+          end
+
+          def read_mounts
+            require 'sys/filesystem'
+            mounts = []
+            Sys::Filesystem.mounts do |fs|
+              device = fs.name
+              filesystem = fs.mount_type
+              path = fs.mount_point
+              options = fs.options.split(',')
+
+              next if path =~ %r{^/(proc|sys)} && filesystem != 'tmpfs'
+              next if filesystem == 'autofs'
+
+              # If the "root" device, lookup the actual device from the kernel options
+              # This is done because not all systems symlink /dev/root
+              device = root_device if device == '/dev/root'
+
+              stats = Sys::Filesystem.stat(path)
+              size_bytes = stats.bytes_total
+              available_bytes = stats.bytes_available
+
+              used_bytes = stats.bytes_used
+              total_bytes = used_bytes + available_bytes
+              capacity = compute_capacity(used_bytes, available_bytes, total_bytes)
+
+              size = Facter::BytesToHumanReadable.convert(size_bytes)
+              available = Facter::BytesToHumanReadable.convert(available_bytes)
+              used = Facter::BytesToHumanReadable.convert(used_bytes)
+
+              mounts << Hash[MOUNT_KEYS.zip(MOUNT_KEYS.map { |v| binding.local_variable_get(v) })]
+            end
+            @fact_list[:mountpoints] = mounts
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/fedora/mountpoints_spec.rb
+++ b/spec/facter/facts/fedora/mountpoints_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe Facter::Fedora::Mountpoints do
+  let(:resolver_output) do
+    [{ available: '63.31 GiB',
+       available_bytes: 67_979_685_888,
+       capacity: '84.64%',
+       device: '/dev/nvme0n1p2',
+       filesystem: 'ext4',
+       options: %w[rw noatime],
+       path: '/',
+       size: '434.42 GiB',
+       size_bytes: 466_449_743_872,
+       used: '348.97 GiB',
+       used_bytes: 374_704_357_376 }]
+  end
+
+  let(:parsed_fact) do
+    { '/': { available: '63.31 GiB',
+             available_bytes: 67_979_685_888,
+             capacity: '84.64%',
+             device: '/dev/nvme0n1p2',
+             filesystem: 'ext4',
+             options: %w[rw noatime],
+             size: '434.42 GiB',
+             size_bytes: 466_449_743_872,
+             used: '348.97 GiB',
+             used_bytes: 374_704_357_376 } }
+  end
+
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'mountpoints', value: parsed_fact)
+      allow(Facter::Resolvers::Linux::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(resolver_output)
+      allow(Facter::ResolvedFact).to receive(:new).with('mountpoints', parsed_fact).and_return(expected_fact)
+
+      fact = described_class.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/sles/memory/swap/available_spec.rb
+++ b/spec/facter/facts/sles/memory/swap/available_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Sles MemorySwapAvailable' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: value)
       allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_free).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', value).and_return(expected_fact)
 
       fact = Facter::Sles::MemorySwapAvailable.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/sles/memory/swap/total_spec.rb
+++ b/spec/facter/facts/sles/memory/swap/total_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Sles MemorySwapTotal' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.total', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.total', value: value)
       allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_total).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.total', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.total', value).and_return(expected_fact)
 
       fact = Facter::Sles::MemorySwapTotal.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/ubuntu/memory/swap/available_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/available_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Ubuntu MemorySwapAvailable' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: value)
       allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_free).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', value).and_return(expected_fact)
 
       fact = Facter::Ubuntu::MemorySwapAvailable.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/ubuntu/memory/swap/used_spec.rb
+++ b/spec/facter/facts/ubuntu/memory/swap/used_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Ubuntu MemorySwapUsed' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used', value: value)
       allow(Facter::Resolvers::Linux::Memory).to receive(:resolve).with(:swap_used_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used', value).and_return(expected_fact)
 
       fact = Facter::Ubuntu::MemorySwapUsed.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/windows/memory/system/available_spec.rb
+++ b/spec/facter/facts/windows/memory/system/available_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Windows MemorySystemAvailable' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.available', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.available', value: value)
       allow(Facter::Resolvers::Memory).to receive(:resolve).with(:available_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.available', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.available', value).and_return(expected_fact)
 
       fact = Facter::Windows::MemorySystemAvailable.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/windows/memory/system/total_spec.rb
+++ b/spec/facter/facts/windows/memory/system/total_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Windows MemorySystemTotal' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.total', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.total', value: value)
       allow(Facter::Resolvers::Memory).to receive(:resolve).with(:total_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.total', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.total', value).and_return(expected_fact)
 
       fact = Facter::Windows::MemorySystemTotal.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/windows/memory/system/used_spec.rb
+++ b/spec/facter/facts/windows/memory/system/used_spec.rb
@@ -2,13 +2,15 @@
 
 describe 'Windows MemorySystemUsed' do
   context '#call_the_resolver' do
+    let(:value) { '1.00 KiB' }
+
     it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used', value: '1.0 KiB')
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used', value: value)
       allow(Facter::Resolvers::Memory).to receive(:resolve).with(:used_bytes).and_return(1024)
-      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used', '1.0 KiB').and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used', value).and_return(expected_fact)
 
       fact = Facter::Windows::MemorySystemUsed.new
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eq('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eq(value)
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts_utils/bytes_to_human_readable_spec.rb
+++ b/spec/facter/facts_utils/bytes_to_human_readable_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 describe 'BytesToHumanReadable' do
-  context '#convert' do
+  describe '.convert' do
     it 'returns nil if bytes variable is nil' do
       expect(Facter::BytesToHumanReadable.convert(nil)).to eql(nil)
     end
 
     it 'returns next unit if result is 1024 after conversion' do
-      expect(Facter::BytesToHumanReadable.convert(1_048_575.7)).to eql('1.0 MiB')
+      expect(Facter::BytesToHumanReadable.convert(1_048_575.7)).to eql('1.00 MiB')
     end
 
     it 'returns bytes if bytes variable is less than 1024' do
@@ -15,11 +15,21 @@ describe 'BytesToHumanReadable' do
     end
 
     it 'returns 1 Kib if bytes variable equals 1024' do
-      expect(Facter::BytesToHumanReadable.convert(1024)).to eql('1.0 KiB')
+      expect(Facter::BytesToHumanReadable.convert(1024)).to eql('1.00 KiB')
     end
 
     it 'returns bytes if number exceeds etta bytes' do
       expect(Facter::BytesToHumanReadable.convert(3_296_472_651_763_232_323_235)).to eql('3296472651763232323235 bytes')
+    end
+  end
+
+  describe '.pad_number' do
+    it 'appends a 0 when conversion has one decimal digit' do
+      expect(Facter::BytesToHumanReadable.send(:pad_number, 10.0)).to eql('10.00')
+    end
+
+    it 'leaves the value unmodified if it has two decimals' do
+      expect(Facter::BytesToHumanReadable.send(:pad_number, 10.23)).to eql('10.23')
     end
   end
 end

--- a/spec/facter/resolvers/mountpoints_resolver_spec.rb
+++ b/spec/facter/resolvers/mountpoints_resolver_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Linux::Mountpoints do
+  let(:mount) do
+    double(Sys::Filesystem::Mount,
+           mount_point: '/', mount_time: nil,
+           mount_type: 'ext4', options: 'rw,noatime', name:
+           '/dev/nvme0n1p2', dump_frequency: 0, pass_number: 0)
+  end
+
+  let(:stat) do
+    double(Sys::Filesystem::Stat,
+           path: '/', base_type: nil, fragment_size: 4096, block_size: 4096, blocks: 113_879_332,
+           blocks_available: 16_596_603, blocks_free: 22_398_776)
+  end
+
+  let(:fact) do
+    [{ available: '63.31 GiB',
+       available_bytes: 67_979_685_888,
+       capacity: '84.64%',
+       device: '/dev/nvme0n1p2',
+       filesystem: 'ext4',
+       options: %w[rw noatime],
+       path: '/',
+       size: '434.42 GiB',
+       size_bytes: 466_449_743_872,
+       used: '348.97 GiB',
+       used_bytes: 374_704_357_376 }]
+  end
+
+  let(:ignored_mounts) do
+    [double(Sys::Filesystem::Mount, mount_type: 'ext4', mount_point: '/proc/a', name: '/dev/ignore', options: 'rw'),
+     double(Sys::Filesystem::Mount, mount_type: 'autofs', mount_point: '/mnt/auto', name: '/dev/ignore', options: 'rw')]
+  end
+
+  before do
+    allow(File).to receive(:read)
+      .with('/proc/cmdline')
+      .and_return(load_fixture('cmdline_root_device').read)
+    allow(Sys::Filesystem).to receive(:mounts).and_yield(mount)
+    allow(Sys::Filesystem).to receive(:stat).with(mount.mount_point).and_return(stat)
+
+    # mock sys/filesystem methods
+    allow(stat).to receive(:bytes_total).and_return(stat.blocks * stat.fragment_size)
+    allow(stat).to receive(:bytes_available).and_return(stat.blocks_available * stat.fragment_size)
+    allow(stat).to receive(:bytes_free).and_return(stat.blocks_free * stat.fragment_size)
+    allow(stat).to receive(:bytes_used).and_return(stat.bytes_total - stat.bytes_free)
+    described_class.invalidate_cache
+  end
+
+  it 'correctly builds the mountpoints fact' do
+    result = described_class.resolve(:mountpoints)
+
+    expect(result).to eq(fact)
+  end
+
+  it 'drops automounts and non-tmpfs mounts under /proc or /sys' do
+    allow(Sys::Filesystem).to receive(:mounts).and_yield(ignored_mounts[0]).and_yield(ignored_mounts[1])
+    result = described_class.resolve(:mountpoints)
+    expect(result).to be_empty
+  end
+
+  describe '.root_device' do
+    let(:mount) do
+      double(Sys::Filesystem::Mount, mount_point: '/', mount_type: 'ext4', options: 'rw,noatime', name: '/dev/root')
+    end
+
+    it 'looks up the actual device if /dev/root' do
+      result = described_class.resolve(:mountpoints)
+      expect(result.first[:device]).to eq('/dev/mmcblk0p2')
+    end
+  end
+
+  describe '.compute_capacity' do
+    it 'returns an integer if full' do
+      capacity = described_class.send(:compute_capacity, 100, 100, 100)
+      expect(capacity).to eq('100%')
+    end
+
+    it 'returns an integer if empty' do
+      capacity = described_class.send(:compute_capacity, 0, 100, 0)
+      expect(capacity).to eq('0%')
+    end
+
+    it 'returns a ratio with 2 decimals otherwise' do
+      capacity = described_class.send(:compute_capacity, 421, 0, 10_000)
+      expect(capacity).to eq('4.21%')
+    end
+  end
+end

--- a/spec/facter/resolvers/mountpoints_resolver_spec.rb
+++ b/spec/facter/resolvers/mountpoints_resolver_spec.rb
@@ -73,17 +73,17 @@ describe Facter::Resolvers::Linux::Mountpoints do
 
   describe '.compute_capacity' do
     it 'returns an integer if full' do
-      capacity = described_class.send(:compute_capacity, 100, 100, 100)
+      capacity = described_class.send(:compute_capacity, 100, 100)
       expect(capacity).to eq('100%')
     end
 
     it 'returns an integer if empty' do
-      capacity = described_class.send(:compute_capacity, 0, 100, 0)
+      capacity = described_class.send(:compute_capacity, 0, 100)
       expect(capacity).to eq('0%')
     end
 
     it 'returns a ratio with 2 decimals otherwise' do
-      capacity = described_class.send(:compute_capacity, 421, 0, 10_000)
+      capacity = described_class.send(:compute_capacity, 421, 10_000)
       expect(capacity).to eq('4.21%')
     end
   end

--- a/spec/fixtures/cmdline_root_device
+++ b/spec/fixtures/cmdline_root_device
@@ -1,0 +1,1 @@
+mem=512M console=ttyS2,115200n8 root=/dev/mmcblk0p2 rw rootwait

--- a/spec/mocks/kernel_mock.rb
+++ b/spec/mocks/kernel_mock.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-LIBS_TO_SKIP = %w[win32ole ffi win32/registry].freeze
+LIBS_TO_SKIP = %w[win32ole ffi win32/registry sys/filesystem].freeze
 module Kernel
   alias old_require require
   def require(path)

--- a/spec/mocks/sys_filesystem_mock.rb
+++ b/spec/mocks/sys_filesystem_mock.rb
@@ -2,6 +2,8 @@
 
 module Sys
   class Filesystem
+    def self.mounts; end
+
     class Mount; end
     class Stat; end
   end

--- a/spec/mocks/sys_filesystem_mock.rb
+++ b/spec/mocks/sys_filesystem_mock.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Sys
+  class Filesystem
+    class Mount; end
+    class Stat; end
+  end
+end


### PR DESCRIPTION
Added dependency to `sys-filesystem` which uses FFI to get filesystem information. Also fixed a bug where `BytesToHumanReadable` did not add 2 digits after the decimal point.