### PR TITLE
(maint) use --force on gem update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   only:
     - master
 before_install:
-  - yes | gem update --system
+  - gem update --system --force
   - gem install bundler
   - bundle install
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Rubygems release version 3.1.2 that contains the fix for --force: rubygems/rubygems#3030
This PR removes the yes workaround in favor for --force