### PR TITLE
(FACT-2210) Memory fact for OSX

### DIFF
--- a/lib/facts/macosx/memory/swap/available.rb
+++ b/lib/facts/macosx/memory/swap/available.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapAvailable
+      FACT_NAME = 'memory.swap.available'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:available_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/available_bytes.rb
+++ b/lib/facts/macosx/memory/swap/available_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapAvailableBytes
+      FACT_NAME = 'memory.swap.available_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:available_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/capacity.rb
+++ b/lib/facts/macosx/memory/swap/capacity.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapCapacity
+      FACT_NAME = 'memory.swap.capacity'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:capacity)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/encrypted.rb
+++ b/lib/facts/macosx/memory/swap/encrypted.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapEncrypted
+      FACT_NAME = 'memory.swap.encrypted'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:encrypted)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/total.rb
+++ b/lib/facts/macosx/memory/swap/total.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapTotal
+      FACT_NAME = 'memory.swap.total'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:total_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/total_bytes.rb
+++ b/lib/facts/macosx/memory/swap/total_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapTotalBytes
+      FACT_NAME = 'memory.swap.total_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:total_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/used.rb
+++ b/lib/facts/macosx/memory/swap/used.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapUsed
+      FACT_NAME = 'memory.swap.used'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:used_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/swap/used_bytes.rb
+++ b/lib/facts/macosx/memory/swap/used_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySwapUsedBytes
+      FACT_NAME = 'memory.swap.used_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SwapMemory.resolve(:used_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/available.rb
+++ b/lib/facts/macosx/memory/system/available.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemAvailable
+      FACT_NAME = 'memory.system.available'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:available_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/available_bytes.rb
+++ b/lib/facts/macosx/memory/system/available_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemAvailableBytes
+      FACT_NAME = 'memory.system.available_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:available_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/capacity.rb
+++ b/lib/facts/macosx/memory/system/capacity.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemCapacity
+      FACT_NAME = 'memory.system.capacity'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:capacity)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/total.rb
+++ b/lib/facts/macosx/memory/system/total.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemTotal
+      FACT_NAME = 'memory.system.total'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:total_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/total_bytes.rb
+++ b/lib/facts/macosx/memory/system/total_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemTotalBytes
+      FACT_NAME = 'memory.system.total_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:total_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/used.rb
+++ b/lib/facts/macosx/memory/system/used.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemUsed
+      FACT_NAME = 'memory.system.used'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:used_bytes)
+        fact_value = BytesToHumanReadable.convert(fact_value)
+
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/facts/macosx/memory/system/used_bytes.rb
+++ b/lib/facts/macosx/memory/system/used_bytes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facter
+  module Macosx
+    class MemorySystemUsedBytes
+      FACT_NAME = 'memory.system.used_bytes'
+
+      def call_the_resolver
+        fact_value = Resolvers::Macosx::SystemMemory.resolve(:used_bytes)
+        ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/resolvers/macosx/swap_memory_resolver.rb
+++ b/lib/resolvers/macosx/swap_memory_resolver.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Macosx
+      class SwapMemory < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        @log = Facter::Log.new(self)
+        class << self
+          def resolve(fact_name)
+            @semaphore.synchronize do
+              result ||= @fact_list[fact_name]
+              subscribe_to_manager
+              result || read_swap_memory(fact_name)
+            end
+          end
+
+          private
+
+          def read_swap_memory(fact_name) # rubocop:disable Metrics/AbcSize
+            output = Open3.capture2('sysctl -n vm.swapusage').first
+            data = output.match(/^total = ([\d.]+)M  used = ([\d.]+)M  free = ([\d.]+)M  (\(encrypted\))$/)
+
+            if data[1].to_f.positive?
+              @fact_list[:total_bytes] = megabytes_to_bytes(data[1])
+              @fact_list[:used_bytes] = megabytes_to_bytes(data[2])
+              @fact_list[:available_bytes] = megabytes_to_bytes(data[3])
+              @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+              @fact_list[:encrypted] = data[4] == '(encrypted)'
+            end
+
+            @fact_list[fact_name]
+          end
+
+          def megabytes_to_bytes(quantity)
+            (quantity.to_f * 1_048_576).to_i
+          end
+
+          def compute_capacity(used, total)
+            format('%.2f', (used / total.to_f * 100)) + '%'
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/resolvers/macosx/system_memory_resolver.rb
+++ b/lib/resolvers/macosx/system_memory_resolver.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Macosx
+      class SystemMemory < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+        @log = Facter::Log.new(self)
+        class << self
+          def resolve(fact_name)
+            @semaphore.synchronize do
+              result ||= @fact_list[fact_name]
+              subscribe_to_manager
+              result || calculate_system_memory(fact_name)
+            end
+          end
+
+          private
+
+          def calculate_system_memory(fact_name)
+            read_total_memory_in_bytes
+            read_available_memory_in_bytes
+
+            @fact_list[:used_bytes] = @fact_list[:total_bytes] - @fact_list[:available_bytes]
+            @fact_list[:capacity] = compute_capacity(@fact_list[:used_bytes], @fact_list[:total_bytes])
+
+            @fact_list[fact_name]
+          end
+
+          def read_available_memory_in_bytes
+            output, _status = Open3.capture2('vm_stat')
+            page_size = output.match(/page size of (\d+) bytes/)[1].to_i
+            pages_free = output.match(/Pages free:\s+(\d+)/)[1].to_i
+
+            @fact_list[:available_bytes] = page_size * pages_free
+          end
+
+          def read_total_memory_in_bytes
+            @fact_list[:total_bytes] = Open3.capture2('sysctl -n hw.memsize').first.to_i
+          end
+
+          def compute_capacity(used, total)
+            format('%.2f', (used / total.to_f * 100)) + '%'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/available_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/available_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapAvailableBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySwapAvailableBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/available_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/available_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapAvailable' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.available', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.available', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySwapAvailable.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/capacity_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/capacity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapCapacity' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.capacity', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:capacity).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.capacity', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySwapCapacity.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/encrypted_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/encrypted_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapEncrypted' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.encrypted', value: true)
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:encrypted).and_return(true)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.encrypted', true).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySwapEncrypted.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/total_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/total_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapTotalBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.total_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.total_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySwapTotalBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/total_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/total_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapTotal' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.total', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.total', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySwapTotal.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/used_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/used_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapUsedBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySwapUsedBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/swap/used_spec.rb
+++ b/spec/facter/facts/macosx/memory/swap/used_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySwapUsed' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.swap.used', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SwapMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.swap.used', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySwapUsed.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/available_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/available_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemAvailableBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.available_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.available_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySystemAvailableBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/available_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/available_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemAvailable' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.available', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:available_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.available', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySystemAvailable.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/capacity_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/capacity_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemCapacity' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.capacity', value: '15.53%')
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:capacity).and_return('15.53%')
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.capacity', '15.53%').and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySystemCapacity.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/total_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/total_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemTotalBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.total_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.total_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySystemTotalBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/total_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/total_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemTotal' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.total', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:total_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.total', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySystemTotal.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/used_bytes_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/used_bytes_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemUsedBytes' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used_bytes', value: 1024)
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used_bytes', 1024).and_return(expected_fact)
+
+      fact = Facter::Macosx::MemorySystemUsedBytes.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/facts/macosx/memory/system/used_spec.rb
+++ b/spec/facter/facts/macosx/memory/system/used_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe 'Macosx MemorySystemUsed' do
+  context '#call_the_resolver' do
+    it 'returns a fact' do
+      expected_fact = double(Facter::ResolvedFact, name: 'memory.system.used', value: '1.0 KiB')
+
+      allow(Facter::Resolvers::Macosx::SystemMemory).to receive(:resolve).with(:used_bytes).and_return(1024)
+      allow(Facter::ResolvedFact).to receive(:new).with('memory.system.used', '1.0 KiB').and_return(expected_fact)
+
+      expect(Facter::BytesToHumanReadable).to receive(:convert).with(1024).and_return('1.0 KiB')
+
+      fact = Facter::Macosx::MemorySystemUsed.new
+      expect(fact.call_the_resolver).to eq(expected_fact)
+    end
+  end
+end

--- a/spec/facter/resolvers/macosx/swap_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/macosx/swap_memory_resolver_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe 'SwapMemoryResolver' do
+  let(:available_bytes) { 1_729_363_968 }
+  let(:total_bytes) { 3_221_225_472 }
+  let(:used_bytes) { 1_491_861_504 }
+  let(:capacity) { '46.31%' }
+  let(:encrypted) { true }
+
+  before do
+    allow(Open3).to receive(:capture2)
+      .with('sysctl -n vm.swapusage')
+      .and_return(['total = 3072.00M  used = 1422.75M  free = 1649.25M  (encrypted)', ''])
+  end
+
+  it 'returns available swap memory in bytes' do
+    result = Facter::Resolvers::Macosx::SwapMemory.resolve(:available_bytes)
+    expect(result).to eq(available_bytes)
+  end
+
+  it 'returns total swap memory in bytes' do
+    result = Facter::Resolvers::Macosx::SwapMemory.resolve(:total_bytes)
+    expect(result).to eq(total_bytes)
+  end
+
+  it 'returns used swap memory in bytes' do
+    result = Facter::Resolvers::Macosx::SwapMemory.resolve(:used_bytes)
+    expect(result).to eq(used_bytes)
+  end
+
+  it 'returns capacity of swap memory' do
+    result = Facter::Resolvers::Macosx::SwapMemory.resolve(:capacity)
+    expect(result).to eq(capacity)
+  end
+
+  it 'returns true because swap memory is encrypted' do
+    result = Facter::Resolvers::Macosx::SwapMemory.resolve(:encrypted)
+    expect(result).to eq(encrypted)
+  end
+end

--- a/spec/facter/resolvers/macosx/system_memory_resolver_spec.rb
+++ b/spec/facter/resolvers/macosx/system_memory_resolver_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe 'SystemMemoryResolver' do
+  let(:available_bytes) { 5_590_519_808 }
+  let(:total_bytes) { 34_359_738_368 }
+  let(:used_bytes) { 28_769_218_560 }
+  let(:capacity) { '83.73%' }
+
+  before do
+    allow(Open3).to receive(:capture2)
+      .with('sysctl -n hw.memsize')
+      .and_return(['34359738368', ''])
+
+    allow(Open3).to receive(:capture2)
+      .with('vm_stat')
+      .and_return([load_fixture('vm_stat').read, ''])
+  end
+
+  it 'returns available system memory in bytes' do
+    result = Facter::Resolvers::Macosx::SystemMemory.resolve(:available_bytes)
+    expect(result).to eq(available_bytes)
+  end
+
+  it 'returns total system memory in bytes' do
+    result = Facter::Resolvers::Macosx::SystemMemory.resolve(:total_bytes)
+    expect(result).to eq(total_bytes)
+  end
+
+  it 'returns total system memory in bytes' do
+    result = Facter::Resolvers::Macosx::SystemMemory.resolve(:used_bytes)
+    expect(result).to eq(used_bytes)
+  end
+
+  it 'returns total system memory in bytes' do
+    result = Facter::Resolvers::Macosx::SystemMemory.resolve(:capacity)
+    expect(result).to eq(capacity)
+  end
+end

--- a/spec/fixtures/vm_stat
+++ b/spec/fixtures/vm_stat
@@ -1,0 +1,23 @@
+Mach Virtual Memory Statistics: (page size of 4096 bytes)
+Pages free:                             1364873.
+Pages active:                           2653007.
+Pages inactive:                         1583485.
+Pages speculative:                      1061442.
+Pages throttled:                              0.
+Pages wired down:                        986842.
+Pages purgeable:                         207521.
+"Translation faults":                2444018907.
+Pages copy-on-write:                  202802362.
+Pages zero filled:                   1466949525.
+Pages reactivated:                      1421652.
+Pages purged:                            277081.
+File-backed pages:                      1562816.
+Anonymous pages:                        3735118.
+Pages stored in compressor:             1909929.
+Pages occupied by compressor:            737949.
+Decompressions:                         8791424.
+Compressions:                          13081516.
+Pageins:                                8432517.
+Pageouts:                                  5901.
+Swapins:                               10474828.
+Swapouts:                              10972484.


### PR DESCRIPTION
There is a mismatch between cfacter's and this implementation's output for the 'memory.system' part of the fact.
- facter-ng's (this implementation) memory.system output is:
```
{
  available => "8.87 GiB",
  available_bytes => 9526980608,
  capacity => "72.27%",
  total => "32.0 GiB",
  total_bytes => 34359738368,
  used => "23.13 GiB",
  used_bytes => 24832757760
}
```
- which matches with data shown in Activity Monitor (Memory Used + Cached Files matches 'used' from above):
> Physical Memory: 32.00 GB
> Memory Used:      17.39 GB
> Cached Files:         5.74 GB
> Swap Used:            1.39 GB
- the data is taken from running 'vm_stat' command:
```
Mach Virtual Memory Statistics: (page size of 4096 bytes)
Pages free:                             2350636.
Pages active:                           2134197.
Pages inactive:                         1245037.
Pages speculative:                       977323.
Pages throttled:                              0.
Pages wired down:                        952429.
Pages purgeable:                         181497.
"Translation faults":                2305257803.
Pages copy-on-write:                  191839770.
Pages zero filled:                   1396362525.
Pages reactivated:                      1388257.
Pages purged:                            276010.
File-backed pages:                      1348187.
Anonymous pages:                        3008370.
Pages stored in compressor:             1970190.
Pages occupied by compressor:            728088.
Decompressions:                         8734794.
Compressions:                          13081516.
Pageins:                                8203778.
Pageouts:                                  5901.
Swapins:                               10393847.
Swapouts:                              10927652.
```
- and 'sysctl -n hw.memsize' which shows total size of ram:
```
34359738368
```
- ### but cfacter's memory.system output is:
```
{
  available => "980.71 MiB",
  available_bytes => 1028354048,
  capacity => "97.01%",
  total => "32.00 GiB",
  total_bytes => 34359738368,
  used => "31.04 GiB",
  used_bytes => 33331384320
}
```
- **implementation:** lib/src/facts/osx/memory_resolver.cc
- - - - - - - - - - - - - - - - - - - - - - - - - - - -
'memory.swap' part of the fact works as expected. 
- facter-ng's memory.swap output is:
```
{
  available => "1.61 GiB",
  available_bytes => 1729363968,
  capacity => "46.31%",
  encrypted => true,
  total => "3.0 GiB",
  total_bytes => 3221225472,
  used => "1.39 GiB",
  used_bytes => 1491861504
}
```
- cfacter's memory.swap output is:
```
{
  available => "1.61 GiB",
  available_bytes => 1729363968,
  capacity => "46.31%",
  encrypted => true,
  total => "3.00 GiB",
  total_bytes => 3221225472,
  used => "1.39 GiB",
  used_bytes => 1491861504
}
```