### PR TITLE
(maint) Relax gem dependencies

### DIFF
--- a/facter-ng.gemspec
+++ b/facter-ng.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubycritic', '~> 4.1.0'
 
   spec.add_runtime_dependency 'bundler', '~> 2.0'
-  spec.add_runtime_dependency 'hocon', '1.3.0'
+  spec.add_runtime_dependency 'hocon', '~> 1.3'
   spec.add_runtime_dependency 'sys-filesystem', '~> 1.3'
-  spec.add_runtime_dependency 'thor', '~> 1.0.1'
+  spec.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2.0']
 end


### PR DESCRIPTION
Relax hocon gem dependency so that the y and z version components can float.
Similarly, relax thor in the same way, but require 1.0.1 or greater.