### PR TITLE
(FACT-2290) Architecture legacy fact

### DIFF
--- a/lib/facts/aix/os/architecture.rb
+++ b/lib/facts/aix/os/architecture.rb
@@ -4,11 +4,11 @@ module Facter
   module Aix
     class OsArchitecture
       FACT_NAME = 'os.architecture'
-
+      ALIASES = 'architecture'
       def call_the_resolver
         fact_value = Resolvers::Architecture.resolve(:architecture)
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/facts/debian/os/architecture.rb
+++ b/lib/facts/debian/os/architecture.rb
@@ -4,12 +4,13 @@ module Facter
   module Debian
     class OsArchitecture
       FACT_NAME = 'os.architecture'
+      ALIASES = 'architecture'
 
       def call_the_resolver
         fact_value = Resolvers::Uname.resolve(:machine)
         fact_value = 'amd64' if fact_value == 'x86_64'
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/facts/fedora/filesystems.rb
+++ b/lib/facts/fedora/filesystems.rb
@@ -2,8 +2,8 @@
 
 module Facter
   module Fedora
-    class Filesystem
-      FACT_NAME = 'filesystem'
+    class Filesystems
+      FACT_NAME = 'filesystems'
 
       def call_the_resolver
         fact_value = Resolvers::Linux::Filesystems.resolve(:systems)

--- a/lib/facts/fedora/mountpoints.rb
+++ b/lib/facts/fedora/mountpoints.rb
@@ -8,6 +8,8 @@ module Facter
       def call_the_resolver
         mountpoints = Resolvers::Linux::Mountpoints.resolve(FACT_NAME.to_sym)
 
+        return ResolvedFact.new(FACT_NAME, mountpoints) unless mountpoints
+
         fact = {}
         mountpoints.each do |mnt|
           fact[mnt[:path].to_sym] = mnt.reject { |k| k == :path }

--- a/lib/facts/fedora/os/architecture.rb
+++ b/lib/facts/fedora/os/architecture.rb
@@ -4,11 +4,12 @@ module Facter
   module Fedora
     class OsArchitecture
       FACT_NAME = 'os.architecture'
+      ALIASES = 'architecture'
 
       def call_the_resolver
         fact_value = Resolvers::Uname.resolve(:machine)
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/facts/opensuse/os/architecture.rb
+++ b/lib/facts/opensuse/os/architecture.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Facter
-  module Solaris
+  module Opensuse
     class OsArchitecture
       FACT_NAME = 'os.architecture'
       ALIASES = 'architecture'
 
       def call_the_resolver
-        fact_value = Facter::Resolvers::Uname.resolve(:machine)
+        fact_value = Resolvers::Uname.resolve(:machine)
 
         [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end

--- a/lib/facts/rhel/os/architecture.rb
+++ b/lib/facts/rhel/os/architecture.rb
@@ -4,11 +4,12 @@ module Facter
   module Rhel
     class OsArchitecture
       FACT_NAME = 'os.architecture'
+      ALIASES = 'architecture'
 
       def call_the_resolver
         fact_value = Resolvers::Uname.resolve(:machine)
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/facts/sles/os/architecture.rb
+++ b/lib/facts/sles/os/architecture.rb
@@ -4,11 +4,12 @@ module Facter
   module Sles
     class OsArchitecture
       FACT_NAME = 'os.architecture'
+      ALIASES = 'architecture'
 
       def call_the_resolver
         fact_value = Resolvers::Uname.resolve(:machine)
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/facts/ubuntu/os/architecture.rb
+++ b/lib/facts/ubuntu/os/architecture.rb
@@ -4,12 +4,13 @@ module Facter
   module Ubuntu
     class OsArchitecture
       FACT_NAME = 'os.architecture'
+      ALIASES = 'architecture'
 
       def call_the_resolver
         fact_value = Resolvers::Uname.resolve(:machine)
         fact_value = 'amd64' if fact_value == 'x86_64'
 
-        ResolvedFact.new(FACT_NAME, fact_value)
+        [ResolvedFact.new(FACT_NAME, fact_value), ResolvedFact.new(ALIASES, fact_value, :legacy)]
       end
     end
   end

--- a/lib/framework/detector/current_os.rb
+++ b/lib/framework/detector/current_os.rb
@@ -41,6 +41,7 @@ class CurrentOs
       break if @identifier
     end
     @identifier = 'ubuntu' if @identifier == 'debian'
+    @identifier = 'fedora' if @identifier == 'amzn'
     @identifier
   end
 

--- a/lib/resolvers/memory_resolver.rb
+++ b/lib/resolvers/memory_resolver.rb
@@ -30,7 +30,10 @@ module Facter
           end
 
           def read_swap(output)
-            @fact_list[:swap_total] = kilobytes_to_bytes(output.match(/SwapTotal:\s+(\d+)\s/)[1])
+            total = output.match(/SwapTotal:\s+(\d+)\s/)[1]
+            return if total.to_i.zero?
+
+            @fact_list[:swap_total] = kilobytes_to_bytes(total)
             @fact_list[:swap_free] = kilobytes_to_bytes(output.match(/SwapFree:\s+(\d+)\s/)[1])
             @fact_list[:swap_used_bytes] = compute_used(@fact_list[:swap_total], @fact_list[:swap_free])
             @fact_list[:swap_capacity] = compute_capacity(@fact_list[:swap_used_bytes], @fact_list[:swap_total])

--- a/spec/facter/facts/aix/os/architecture_spec.rb
+++ b/spec/facter/facts/aix/os/architecture_spec.rb
@@ -2,13 +2,22 @@
 
 describe 'AIX OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'value')
-      allow(Facter::Resolvers::Architecture).to receive(:resolve).with(:architecture).and_return('value')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'value').and_return(expected_fact)
+    let(:value) { 'x86_64' }
+    subject(:fact) { Facter::Aix::OsArchitecture.new }
 
-      fact = Facter::Aix::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Architecture).to receive(:resolve).with(:architecture).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Architecture' do
+      expect(Facter::Resolvers::Architecture).to receive(:resolve).with(:architecture)
+      fact.call_the_resolver
+    end
+
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/debian/architecture_spec.rb
+++ b/spec/facter/facts/debian/architecture_spec.rb
@@ -2,22 +2,22 @@
 
 describe 'Debian OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'value')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('value')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'value').and_return(expected_fact)
+    let(:value) { 'x86_64' }
+    subject(:fact) { Facter::Debian::OsArchitecture.new }
 
-      fact = Facter::Debian::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
     end
 
-    it 'returns a amd64 if resolver returns x86_64' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'amd64')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('x86_64')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'amd64').and_return(expected_fact)
+    it 'calls Facter::Resolvers::Uname' do
+      expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+      fact.call_the_resolver
+    end
 
-      fact = Facter::Debian::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: 'amd64'),
+                        an_object_having_attributes(name: 'architecture', value: 'amd64', type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/fedora/filesystems_spec.rb
+++ b/spec/facter/facts/fedora/filesystems_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-describe 'Fedora Filesystem' do
+describe 'Fedora Filesystems' do
   context '#call_the_resolver' do
     it 'returns a fact' do
       value = 'ext2,ext3,ext4,xfs'
-      expected_fact = double(Facter::ResolvedFact, name: 'filesystem', value: value)
+      expected_fact = double(Facter::ResolvedFact, name: 'filesystems', value: value)
       allow(Facter::Resolvers::Linux::Filesystems).to receive(:resolve).with(:systems).and_return(value)
-      allow(Facter::ResolvedFact).to receive(:new).with('filesystem', value).and_return(expected_fact)
+      allow(Facter::ResolvedFact).to receive(:new).with('filesystems', value).and_return(expected_fact)
 
-      fact = Facter::Fedora::Filesystem.new
+      fact = Facter::Fedora::Filesystems.new
       expect(fact.call_the_resolver).to eq(expected_fact)
     end
   end

--- a/spec/facter/facts/fedora/mountpoints_spec.rb
+++ b/spec/facter/facts/fedora/mountpoints_spec.rb
@@ -1,41 +1,58 @@
 # frozen_string_literal: true
 
 describe Facter::Fedora::Mountpoints do
-  let(:resolver_output) do
-    [{ available: '63.31 GiB',
-       available_bytes: 67_979_685_888,
-       capacity: '84.64%',
-       device: '/dev/nvme0n1p2',
-       filesystem: 'ext4',
-       options: %w[rw noatime],
-       path: '/',
-       size: '434.42 GiB',
-       size_bytes: 466_449_743_872,
-       used: '348.97 GiB',
-       used_bytes: 374_704_357_376 }]
-  end
-
-  let(:parsed_fact) do
-    { '/': { available: '63.31 GiB',
-             available_bytes: 67_979_685_888,
-             capacity: '84.64%',
-             device: '/dev/nvme0n1p2',
-             filesystem: 'ext4',
-             options: %w[rw noatime],
-             size: '434.42 GiB',
-             size_bytes: 466_449_743_872,
-             used: '348.97 GiB',
-             used_bytes: 374_704_357_376 } }
-  end
-
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'mountpoints', value: parsed_fact)
-      allow(Facter::Resolvers::Linux::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(resolver_output)
-      allow(Facter::ResolvedFact).to receive(:new).with('mountpoints', parsed_fact).and_return(expected_fact)
+    subject(:fact) { Facter::Fedora::Mountpoints.new }
 
-      fact = described_class.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    context 'when resolver returns hash' do
+      let(:resolver_output) do
+        [{ available: '63.31 GiB',
+           available_bytes: 67_979_685_888,
+           capacity: '84.64%',
+           device: '/dev/nvme0n1p2',
+           filesystem: 'ext4',
+           options: %w[rw noatime],
+           path: '/',
+           size: '434.42 GiB',
+           size_bytes: 466_449_743_872,
+           used: '348.97 GiB',
+           used_bytes: 374_704_357_376 }]
+      end
+      let(:parsed_fact) do
+        { '/': { available: '63.31 GiB',
+                 available_bytes: 67_979_685_888,
+                 capacity: '84.64%',
+                 device: '/dev/nvme0n1p2',
+                 filesystem: 'ext4',
+                 options: %w[rw noatime],
+                 size: '434.42 GiB',
+                 size_bytes: 466_449_743_872,
+                 used: '348.97 GiB',
+                 used_bytes: 374_704_357_376 } }
+      end
+      before do
+        allow(Facter::Resolvers::Linux::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(resolver_output)
+      end
+      it 'calls Facter::Resolvers::Linux::Mountpoints' do
+        expect(Facter::Resolvers::Linux::Mountpoints).to receive(:resolve).with(:mountpoints)
+        fact.call_the_resolver
+      end
+
+      it 'returns mountpoints information' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'mountpoints', value: parsed_fact)
+      end
+    end
+
+    context 'when resolver returns nil' do
+      before do
+        allow(Facter::Resolvers::Linux::Mountpoints).to receive(:resolve).with(:mountpoints).and_return(nil)
+      end
+
+      it 'returns mountpoints information' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'mountpoints', value: nil)
+      end
     end
   end
 end

--- a/spec/facter/facts/macosx/os/architecture_spec.rb
+++ b/spec/facter/facts/macosx/os/architecture_spec.rb
@@ -2,17 +2,22 @@
 
 describe 'Macosx OsArchitecture' do
   context '#call_the_resolver' do
-    let(:expected_fact) do
-      [double(Facter::ResolvedFact, name: 'os.architecture', value: 'x86_64'),
-       double(Facter::ResolvedFact, name: 'architecture', value: 'x86_64', type: :legacy)]
-    end
-    it 'returns a fact' do
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('x86_64')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'x86_64').and_return(expected_fact[0])
-      allow(Facter::ResolvedFact).to receive(:new).with('architecture', 'x86_64', :legacy).and_return(expected_fact[1])
+    let(:value) { 'x86_64' }
+    subject(:fact) { Facter::Macosx::OsArchitecture.new }
 
-      fact = Facter::Macosx::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Uname' do
+      expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+      fact.call_the_resolver
+    end
+
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/opensuse/os/architecture_spec.rb
+++ b/spec/facter/facts/opensuse/os/architecture_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-describe 'Fedora OsArchitecture' do
+describe 'Opensuse OsArchitecture' do
   context '#call_the_resolver' do
     let(:value) { 'x86_64' }
-    subject(:fact) { Facter::Fedora::OsArchitecture.new }
+    subject(:fact) { Facter::Opensuse::OsArchitecture.new }
 
     before do
       allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)

--- a/spec/facter/facts/rhel/os/architecture_spec.rb
+++ b/spec/facter/facts/rhel/os/architecture_spec.rb
@@ -2,13 +2,22 @@
 
 describe 'Rhel OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'Value')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('value')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'value').and_return(expected_fact)
+    let(:value) { 'x86_64' }
+    subject(:fact) { Facter::Rhel::OsArchitecture.new }
 
-      fact = Facter::Rhel::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Uname' do
+      expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+      fact.call_the_resolver
+    end
+
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/sles/os/architecture_spec.rb
+++ b/spec/facter/facts/sles/os/architecture_spec.rb
@@ -2,13 +2,22 @@
 
 describe 'Sles OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'value')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('value')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'value').and_return(expected_fact)
+    let(:value) { 'x86_64' }
+    subject(:fact) { Facter::Sles::OsArchitecture.new }
 
-      fact = Facter::Sles::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Uname' do
+      expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+      fact.call_the_resolver
+    end
+
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/solaris/os/architecture_spec.rb
+++ b/spec/facter/facts/solaris/os/architecture_spec.rb
@@ -2,13 +2,22 @@
 
 describe 'Solaris OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'i86pc')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('i86pc')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'i86pc').and_return(expected_fact)
+    let(:value) { 'i86pc' }
+    subject(:fact) { Facter::Solaris::OsArchitecture.new }
 
-      fact = Facter::Solaris::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+    before do
+      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::Uname' do
+      expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+      fact.call_the_resolver
+    end
+
+    it 'returns architecture fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/ubuntu/os/architecture_spec.rb
+++ b/spec/facter/facts/ubuntu/os/architecture_spec.rb
@@ -2,22 +2,43 @@
 
 describe 'Ubuntu OsArchitecture' do
   context '#call_the_resolver' do
-    it 'returns a fact' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'value')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('value')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'value').and_return(expected_fact)
+    subject(:fact) { Facter::Ubuntu::OsArchitecture.new }
+    context 'when resolver does not return x86_64' do
+      let(:value) { 'i86pc' }
 
-      fact = Facter::Ubuntu::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
+        expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+        fact.call_the_resolver
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                          an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
+      end
     end
 
-    it 'returns amd64 if resolver returns x86_64' do
-      expected_fact = double(Facter::ResolvedFact, name: 'os.architecture', value: 'amd64')
-      allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return('x86_64')
-      allow(Facter::ResolvedFact).to receive(:new).with('os.architecture', 'amd64').and_return(expected_fact)
+    context 'when resolver returns x86_64' do
+      let(:value) { 'x86_64' }
 
-      fact = Facter::Ubuntu::OsArchitecture.new
-      expect(fact.call_the_resolver).to eq(expected_fact)
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
+        expect(Facter::Resolvers::Uname).to receive(:resolve).with(:machine)
+        fact.call_the_resolver
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: 'amd64'),
+                          an_object_having_attributes(name: 'architecture', value: 'amd64', type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/resolvers/memory_resolver_spec.rb
+++ b/spec/facter/resolvers/memory_resolver_spec.rb
@@ -1,65 +1,101 @@
 # frozen_string_literal: true
 
 describe 'MemoryResolver' do
-  let(:total) { 4_036_680 * 1024 }
-  let(:free) { 3_547_792 * 1024 }
-  let(:used) { total - free }
-  let(:swap_total) { 2_097_148 * 1024 }
-  let(:swap_free) { 2_097_148 * 1024 }
-  let(:swap_used) { swap_total - swap_free }
-
   before do
     allow(File).to receive(:read)
       .with('/proc/meminfo')
-      .and_return(load_fixture('meminfo').read)
-  end
-  it 'returns total memory' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:total)
-
-    expect(result).to eq(total)
+      .and_return(load_fixture(fixture_name).read)
   end
 
-  it 'returns memfree' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:memfree)
+  after do
+    Facter::Resolvers::Linux::Memory.invalidate_cache
+  end
+  subject(:resolver) { Facter::Resolvers::Linux::Memory }
 
-    expect(result).to eq(free)
+  context 'when there is swap memory' do
+    let(:total) { 4_036_680 * 1024 }
+    let(:free) { 3_547_792 * 1024 }
+    let(:used) { total - free }
+    let(:swap_total) { 2_097_148 * 1024 }
+    let(:swap_free) { 2_097_148 * 1024 }
+    let(:swap_used) { swap_total - swap_free }
+    let(:fixture_name) { 'meminfo' }
+
+    it 'returns total memory' do
+      expect(resolver.resolve(:total)).to eq(total)
+    end
+
+    it 'returns memfree' do
+      expect(resolver.resolve(:memfree)).to eq(free)
+    end
+
+    it 'returns swap total' do
+      expect(resolver.resolve(:swap_total)).to eq(swap_total)
+    end
+
+    it 'returns swap available' do
+      expect(resolver.resolve(:swap_free)).to eq(swap_free)
+    end
+
+    it 'returns swap capacity' do
+      swap_capacity = format('%<swap_capacity>.2f', swap_capacity: (swap_used / swap_total.to_f * 100)) + '%'
+
+      expect(resolver.resolve(:swap_capacity)).to eq(swap_capacity)
+    end
+
+    it 'returns swap usage' do
+      expect(resolver.resolve(:swap_used_bytes)).to eq(swap_used)
+    end
+
+    it 'returns system capacity' do
+      system_capacity = format('%<capacity>.2f', capacity: (used / total.to_f * 100)) + '%'
+
+      expect(resolver.resolve(:capacity)).to eq(system_capacity)
+    end
+
+    it 'returns system usage' do
+      expect(resolver.resolve(:used_bytes)).to eq(used)
+    end
   end
 
-  it 'returns swap total' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:swap_total)
+  context 'when there is not swap memory' do
+    let(:total) { 4_134_510_592 }
+    let(:free) { 3_465_723_904 }
+    let(:used) { total - free }
+    let(:fixture_name) { 'meminfo2' }
 
-    expect(result).to eq(swap_total)
-  end
+    it 'returns total memory' do
+      expect(resolver.resolve(:total)).to eq(total)
+    end
 
-  it 'returns swap available' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:swap_free)
+    it 'returns memfree' do
+      expect(resolver.resolve(:memfree)).to eq(free)
+    end
 
-    expect(result).to eq(swap_free)
-  end
+    it 'returns swap total as nil' do
+      expect(resolver.resolve(:swap_total)).to eq(nil)
+    end
 
-  it 'returns swap capacity' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:swap_capacity)
-    swap_capacity = format('%<swap_capacity>.2f', swap_capacity: (swap_used / swap_total.to_f * 100)) + '%'
+    it 'returns swap available as nil' do
+      expect(resolver.resolve(:swap_free)).to eq(nil)
+    end
 
-    expect(result).to eq(swap_capacity)
-  end
+    it 'returns swap capacity as nil' do
+      expect(resolver.resolve(:swap_capacity)).to eq(nil)
+    end
 
-  it 'returns swap usage' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:swap_used_bytes)
+    it 'returns swap usage as nil' do
+      expect(resolver.resolve(:swap_used_bytes)).to eq(nil)
+    end
 
-    expect(result).to eq(swap_used)
-  end
+    it 'returns system capacity' do
+      system_capacity = format('%<capacity>.2f', capacity: (used / total.to_f * 100)) + '%'
 
-  it 'returns system capacity' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:capacity)
-    system_capacity = format('%<capacity>.2f', capacity: (used / total.to_f * 100)) + '%'
+      expect(resolver.resolve(:capacity)).to eq(system_capacity)
+    end
 
-    expect(result).to eq(system_capacity)
-  end
-
-  it 'returns system usage' do
-    result = Facter::Resolvers::Linux::Memory.resolve(:used_bytes)
-
-    expect(result).to eq(used)
+    it 'returns system usage' do
+      expect(resolver.resolve(:used_bytes)).to eq(used)
+    end
   end
 end

--- a/spec/fixtures/meminfo2
+++ b/spec/fixtures/meminfo2
@@ -1,0 +1,45 @@
+MemTotal:        4037608 kB
+MemFree:         3384496 kB
+MemAvailable:    3665024 kB
+Buffers:            2088 kB
+Cached:           445204 kB
+SwapCached:            0 kB
+Active:           206832 kB
+Inactive:         273488 kB
+Active(anon):      33224 kB
+Inactive(anon):      284 kB
+Active(file):     173608 kB
+Inactive(file):   273204 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:             0 kB
+SwapFree:              0 kB
+Dirty:                48 kB
+Writeback:             0 kB
+AnonPages:         33124 kB
+Mapped:            42864 kB
+Shmem:               480 kB
+Slab:             111772 kB
+SReclaimable:      71384 kB
+SUnreclaim:        40388 kB
+KernelStack:        2112 kB
+PageTables:         5772 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     2018804 kB
+Committed_AS:     214484 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:           0 kB
+VmallocChunk:          0 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:         0 kB
+ShmemHugePages:        0 kB
+ShmemPmdMapped:        0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:       96256 kB
+DirectMap2M:     4098048 kB


### PR DESCRIPTION
- Translate Amazon Linux as Fedora in CurrentOs class
- Handle case when memory swap is 0
- Rename filesystems fact instead of **filesystem** 
- Handle for nil return from resolver in mountpoints fact(Fedora)
- Add os.architecture fact for Opensuse
- Add  architecture legacy fact on all os'es