### PR TITLE
(FACT-2353) Fix mountpoints fact crashes on OSX

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -6,7 +6,7 @@ set -e
 rspec
 
 # run linting
-rubocop
+rubocop --parallel
 
 # It will be disabled untill we rewrite it's rules
 # rubycritic --no-browser -f console

--- a/lib/facts/macosx/mountpoints.rb
+++ b/lib/facts/macosx/mountpoints.rb
@@ -9,12 +9,7 @@ module Facter
         mountpoints = Resolvers::Macosx::Mountpoints.resolve(FACT_NAME.to_sym)
         return ResolvedFact.new(FACT_NAME, nil) unless mountpoints
 
-        fact = {}
-        mountpoints.each do |mnt|
-          fact[mnt[:path].to_sym] = mnt.reject { |k| k == :path }
-        end
-
-        ResolvedFact.new(FACT_NAME, fact)
+        ResolvedFact.new(FACT_NAME, mountpoints)
       end
     end
   end

--- a/spec/facter/facts/macosx/mountpoints_spec.rb
+++ b/spec/facter/facts/macosx/mountpoints_spec.rb
@@ -15,7 +15,7 @@ describe Facter::Macosx::Mountpoints do
                  size: '434.42 GiB',
                  size_bytes: 466_449_743_872,
                  used: '348.97 GiB',
-                 used_bytes: 374_704_357_376 }}
+                 used_bytes: 374_704_357_376 } }
       end
 
       let(:parsed_fact) do

--- a/spec/facter/facts/macosx/mountpoints_spec.rb
+++ b/spec/facter/facts/macosx/mountpoints_spec.rb
@@ -6,17 +6,16 @@ describe Facter::Macosx::Mountpoints do
 
     context 'when resolver returns hash' do
       let(:resolver_output) do
-        [{ available: '63.31 GiB',
-           available_bytes: 67_979_685_888,
-           capacity: '84.64%',
-           device: '/dev/nvme0n1p2',
-           filesystem: 'ext4',
-           options: %w[rw noatime],
-           path: '/',
-           size: '434.42 GiB',
-           size_bytes: 466_449_743_872,
-           used: '348.97 GiB',
-           used_bytes: 374_704_357_376 }]
+        { '/': { available: '63.31 GiB',
+                 available_bytes: 67_979_685_888,
+                 capacity: '84.64%',
+                 device: '/dev/nvme0n1p2',
+                 filesystem: 'ext4',
+                 options: %w[rw noatime],
+                 size: '434.42 GiB',
+                 size_bytes: 466_449_743_872,
+                 used: '348.97 GiB',
+                 used_bytes: 374_704_357_376 }}
       end
 
       let(:parsed_fact) do
@@ -42,6 +41,7 @@ describe Facter::Macosx::Mountpoints do
       end
 
       it 'returns mountpoints information' do
+        require 'pry-byebug'
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'mountpoints', value: parsed_fact)
       end

--- a/spec/facter/facts/macosx/mountpoints_spec.rb
+++ b/spec/facter/facts/macosx/mountpoints_spec.rb
@@ -41,7 +41,6 @@ describe Facter::Macosx::Mountpoints do
       end
 
       it 'returns mountpoints information' do
-        require 'pry-byebug'
         expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
           have_attributes(name: 'mountpoints', value: parsed_fact)
       end

--- a/spec/facter/resolvers/macosx/mountpoints_resolver_spec.rb
+++ b/spec/facter/resolvers/macosx/mountpoints_resolver_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 describe Facter::Resolvers::Macosx::Mountpoints do
+  module Sys
+    class Filesystem
+      class Error < StandardError
+      end
+    end
+  end
+
   let(:mount) do
     double(Sys::Filesystem::Mount,
            mount_point: '/', mount_time: nil,
@@ -63,6 +70,31 @@ describe Facter::Resolvers::Macosx::Mountpoints do
     it 'looks up the actual device if /dev/root' do
       result = described_class.resolve(:mountpoints)
       expect(result['/'][:device]).to eq('/dev/root')
+    end
+
+    context 'when mountpoint cannot be accessed' do
+      let(:expected_fact) do
+        { '/' => { available: '0 bytes',
+                   available_bytes: 0,
+                   capacity: '100%',
+                   device: '/dev/root',
+                   filesystem: 'ext4',
+                   options: %w[rw noatime],
+                   size: '0 bytes',
+                   size_bytes: 0,
+                   used: '0 bytes',
+                   used_bytes: 0 } }
+      end
+
+      before do
+        allow(Facter::FilesystemHelper).to \
+          receive(:read_mountpoint_stats).and_raise(Sys::Filesystem::Error)
+      end
+
+      it 'fallbacks to default values' do
+        result = described_class.resolve(:mountpoints)
+        expect(result).to eq(expected_fact)
+      end
     end
   end
 end

--- a/spec/facter/resolvers/macosx/mountpoints_resolver_spec.rb
+++ b/spec/facter/resolvers/macosx/mountpoints_resolver_spec.rb
@@ -15,17 +15,16 @@ describe Facter::Resolvers::Macosx::Mountpoints do
   end
 
   let(:fact) do
-    [{ available: '85.44 GiB',
-       available_bytes: 91_745_386_496,
-       capacity: '80.33%',
-       device: '/dev/nvme0n1p2',
-       filesystem: 'ext4',
-       options: %w[rw noatime],
-       path: '/',
-       size: '434.42 GiB',
-       size_bytes: 466_449_743_872,
-       used: '348.97 GiB',
-       used_bytes: 374_704_357_376 }]
+    { '/' => { available: '85.44 GiB',
+               available_bytes: 91_745_386_496,
+               capacity: '80.33%',
+               device: '/dev/nvme0n1p2',
+               filesystem: 'ext4',
+               options: %w[rw noatime],
+               size: '434.42 GiB',
+               size_bytes: 466_449_743_872,
+               used: '348.97 GiB',
+               used_bytes: 374_704_357_376 } }
   end
 
   let(:ignored_mounts) do
@@ -47,8 +46,7 @@ describe Facter::Resolvers::Macosx::Mountpoints do
 
   it 'correctly builds the mountpoints fact' do
     result = described_class.resolve(:mountpoints)
-
-    expect(result).to eq(fact)
+    expect(result).to match(fact)
   end
 
   it 'drops automounts and non-tmpfs mounts under /proc or /sys' do
@@ -64,7 +62,7 @@ describe Facter::Resolvers::Macosx::Mountpoints do
 
     it 'looks up the actual device if /dev/root' do
       result = described_class.resolve(:mountpoints)
-      expect(result.first[:device]).to eq('/dev/root')
+      expect(result['/'][:device]).to eq('/dev/root')
     end
   end
 end


### PR DESCRIPTION
```
{
  / => {
    available => "29.72 GiB",
    available_bytes => 31916617728,
    capacity => "25.32%",
    device => "/dev/disk1s5",
    filesystem => "apfs",
    options => [
      "read-only",
      "local",
      "root",
      "journaled"
    ],
    size => "39.80 GiB",
    size_bytes => 42739916800,
    used => "10.08 GiB",
    used_bytes => 10823299072
  },
  /System/Volumes/Data => {
    available => "32.63 GiB",
    available_bytes => 35036340224,
    capacity => "18.02%",
    device => "/dev/disk1s1",
    filesystem => "apfs",
    options => [
      "local",
      "nobrowse",
      "journaled"
    ],
    size => "39.80 GiB",
    size_bytes => 42739916800,
    used => "7.17 GiB",
    used_bytes => 7703576576
  },
  /Volumes/VMware Shared Folders => {
    available => "0 bytes",
    available_bytes => 0,
    capacity => "100%",
    device => ".host:/VMware Shared Folders",
    filesystem => "vmhgfs",
    size => "0 bytes",
    size_bytes => 0,
    used => "0 bytes",
    used_bytes => 0
  },
  /Volumes/puppet-agent-6.12.0-1.osx10.14 => {
    available => "6.45 MiB",
    available_bytes => 6758400,
    capacity => "82.44%",
    device => "/dev/disk2s1",
    filesystem => "hfs",
    options => [
      "read-only",
      "nosuid",
      "nodev",
      "local",
      "noowners"
    ],
    size => "36.70 MiB",
    size_bytes => 38481920,
    used => "30.25 MiB",
    used_bytes => 31723520
  },
  /dev => {
    available => "0 bytes",
    available_bytes => 0,
    capacity => "100%",
    device => "devfs",
    filesystem => "devfs",
    options => [
      "local",
      "nobrowse"
    ],
    size => "184.00 KiB",
    size_bytes => 188416,
    used => "184.00 KiB",
    used_bytes => 188416
  },
  /private/var/vm => {
    available => "38.80 GiB",
    available_bytes => 41665105920,
    capacity => "2.51%",
    device => "/dev/disk1s4",
    filesystem => "apfs",
    options => [
      "local",
      "nobrowse",
      "journaled"
    ],
    size => "39.80 GiB",
    size_bytes => 42739916800,
    used => "1.00 GiB",
    used_bytes => 1074810880
  }
}
```