### PR TITLE
(maint) update travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 language: ruby
 cache:
   bundler: true
@@ -12,7 +12,7 @@ before_install:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
-matrix:
+jobs:
   include:
     - rvm: 2.6
       script:


### PR DESCRIPTION
 - removed `sudo:false` as it is deprecated and caused reporters to get stuck
 - explictly set os to linux
 - used jobs instead of matrix as matrix is an alias for jobs

```
Build config validation
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: missing os, using the default linux
root: key matrix is an alias for jobs, using jobs
```