### PR TITLE
(FACT-2431) Fix Legacy::Util::Fact name attribute

### DIFF
--- a/lib/custom_facts/util/fact.rb
+++ b/lib/custom_facts/util/fact.rb
@@ -11,7 +11,7 @@ module LegacyFacter
     class Fact
       # The name of the fact
       # @return [String]
-      attr_accessor :name
+      attr_reader :name
 
       # @return [String]
       # @deprecated

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -24,7 +24,6 @@ describe LegacyFacter::Util::Fact do
 
   describe '#name' do
     it 'changing the name raises error' do
-      fact.name
       expect { fact.name = 'new name' }.to raise_error(NoMethodError)
     end
   end

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -22,6 +22,13 @@ describe LegacyFacter::Util::Fact do
     end
   end
 
+  describe '#name' do
+    it 'changing the name raises error' do
+      fact.name
+      expect{fact.name = 'new name'}.to raise_error(NoMethodError)
+    end
+  end
+
   describe '#add' do
     it 'persists options' do
       fact.add(options) {}

--- a/spec/custom_facts/util/fact_spec.rb
+++ b/spec/custom_facts/util/fact_spec.rb
@@ -25,7 +25,7 @@ describe LegacyFacter::Util::Fact do
   describe '#name' do
     it 'changing the name raises error' do
       fact.name
-      expect{fact.name = 'new name'}.to raise_error(NoMethodError)
+      expect { fact.name = 'new name' }.to raise_error(NoMethodError)
     end
   end
 
@@ -169,6 +169,7 @@ describe LegacyFacter::Util::Fact do
         def suitable?
           false
         end
+
         has_weight 2
         setcode { 2 }
       end


### PR DESCRIPTION
Changed the attribute accessor for the Fact name to attr_reader to match the behaviour in Facter 3.