### PR TITLE
(FACT-2459) Use util method to convert from B to MB

### DIFF
--- a/lib/facts/el/memory/swap/available_bytes.rb
+++ b/lib/facts/el/memory/swap/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_free)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/el/memory/swap/total_bytes.rb
+++ b/lib/facts/el/memory/swap/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_total)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/el/memory/system/available_bytes.rb
+++ b/lib/facts/el/memory/system/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:memfree)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/el/memory/system/total_bytes.rb
+++ b/lib/facts/el/memory/system/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:total)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/macosx/memory/swap/available_bytes.rb
+++ b/lib/facts/macosx/memory/swap/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Macosx::SwapMemory.resolve(:available_bytes)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/macosx/memory/swap/total_bytes.rb
+++ b/lib/facts/macosx/memory/swap/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Macosx::SwapMemory.resolve(:total_bytes)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/macosx/memory/system/available_bytes.rb
+++ b/lib/facts/macosx/memory/system/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Macosx::SystemMemory.resolve(:available_bytes)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/macosx/memory/system/total_bytes.rb
+++ b/lib/facts/macosx/memory/system/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Macosx::SystemMemory.resolve(:total_bytes)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/sles/memory/swap/available_bytes.rb
+++ b/lib/facts/sles/memory/swap/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_free)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/sles/memory/swap/total_bytes.rb
+++ b/lib/facts/sles/memory/swap/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:swap_total)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/sles/memory/system/available_bytes.rb
+++ b/lib/facts/sles/memory/system/available_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:memfree)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/sles/memory/system/total_bytes.rb
+++ b/lib/facts/sles/memory/system/total_bytes.rb
@@ -11,7 +11,7 @@ module Facts
           def call_the_resolver
             fact_value = Facter::Resolvers::Linux::Memory.resolve(:total)
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/windows/memory/system/available_bytes.rb
+++ b/lib/facts/windows/memory/system/available_bytes.rb
@@ -12,7 +12,7 @@ module Facts
             fact_value = Facter::Resolvers::Memory.resolve(:available_bytes)
 
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end

--- a/lib/facts/windows/memory/system/total_bytes.rb
+++ b/lib/facts/windows/memory/system/total_bytes.rb
@@ -12,7 +12,7 @@ module Facts
             fact_value = Facter::Resolvers::Memory.resolve(:total_bytes)
 
             [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value ? (fact_value / (1024.0 * 1024.0)).round(2) : nil, :legacy)]
+             Facter::ResolvedFact.new(ALIASES, Facter::FactsUtils::BytesConverter.to_mb(fact_value), :legacy)]
           end
         end
       end


### PR DESCRIPTION
All memory facts that need conversion form bytes to megabytes use an util method