### PR TITLE
(FACT-2482) Fix processorcount legacy variable

### DIFF
--- a/lib/facts/el/processors/count.rb
+++ b/lib/facts/el/processors/count.rb
@@ -5,7 +5,7 @@ module Facts
     module Processors
       class Count
         FACT_NAME = 'processors.count'
-        ALIASES = 'processorscount'
+        ALIASES = 'processorcount'
 
         def call_the_resolver
           fact_value = Facter::Resolvers::Linux::Processors.resolve(:processors)

--- a/lib/facts/sles/processors/count.rb
+++ b/lib/facts/sles/processors/count.rb
@@ -5,7 +5,7 @@ module Facts
     module Processors
       class Count
         FACT_NAME = 'processors.count'
-        ALIASES = 'processorscount'
+        ALIASES = 'processorcount'
 
         def call_the_resolver
           fact_value = Facter::Resolvers::Linux::Processors.resolve(:processors)

--- a/spec/facter/facts/el/processors/count_spec.rb
+++ b/spec/facter/facts/el/processors/count_spec.rb
@@ -19,7 +19,7 @@ describe Facts::El::Processors::Count do
     it 'returns a resolved fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
         contain_exactly(an_object_having_attributes(name: 'processors.count', value: processors_count),
-                        an_object_having_attributes(name: 'processorscount', value: processors_count, type: :legacy))
+                        an_object_having_attributes(name: 'processorcount', value: processors_count, type: :legacy))
     end
   end
 end

--- a/spec/facter/facts/sles/processors/count_spec.rb
+++ b/spec/facter/facts/sles/processors/count_spec.rb
@@ -19,7 +19,7 @@ describe Facts::Sles::Processors::Count do
     it 'returns a resolved fact' do
       expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
         contain_exactly(an_object_having_attributes(name: 'processors.count', value: processors_count),
-                        an_object_having_attributes(name: 'processorscount', value: processors_count, type: :legacy))
+                        an_object_having_attributes(name: 'processorcount', value: processors_count, type: :legacy))
     end
   end
 end


### PR DESCRIPTION
PR #361 added the legacy fact names, however the processor count legacy
fact was incorrectly configured to be 'processorscount' when
'processorcount' is the name in the documentation.

https://puppet.com/docs/facter/3.7/core_facts.html#processorcount