### PR TITLE
(FACT-2498) Internal fact loader should only load facts once

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,7 +25,6 @@ RSpec/AnyInstance:
     - 'spec/facter/resolvers/windows/virtualization_resolver_spec.rb'
     - 'spec/facter/resolvers/windows/win_os_description_resolver_spec.rb'
     - 'spec/framework/core/fact_loaders/class_discoverer_spec.rb'
-    - 'spec/framework/core/fact_loaders/internal_fact_loader_spec.rb'
     - 'spec/framework/core/fact_manager_spec.rb'
     - 'spec/framework/core/options/options_validator_spec.rb'
     - 'spec/mocks/util.rb'
@@ -51,7 +50,6 @@ RSpec/ContextWording:
     - 'spec/facter/resolvers/utils/windows/network_utils_spec.rb'
     - 'spec/framework/config/config_reader_spec.rb'
     - 'spec/framework/core/fact_loaders/external_fact_loader_spec.rb'
-    - 'spec/framework/core/fact_loaders/internal_fact_loader_spec.rb'
     - 'spec/framework/core/options_spec.rb'
     - 'spec/framework/formatters/legacy_fact_formatter_spec.rb'
 

--- a/lib/framework/core/fact_loaders/internal_fact_loader.rb
+++ b/lib/framework/core/fact_loaders/internal_fact_loader.rb
@@ -35,7 +35,7 @@ module Facter
         fact_name = class_name::FACT_NAME
 
         # if fact is already loaded, skip it
-        next if @facts.select { |fact| fact.name == fact_name }.any?
+        next if @facts.any? { |fact| fact.name == fact_name }
 
         type = fact_name.end_with?('.*') ? :legacy : :core
         load_fact(fact_name, class_name, type)

--- a/lib/framework/core/fact_loaders/internal_fact_loader.rb
+++ b/lib/framework/core/fact_loaders/internal_fact_loader.rb
@@ -16,13 +16,13 @@ module Facter
       @facts = []
 
       os_descendents = OsDetector.instance.hierarchy
-      load_all_oses(os_descendents)
+      load_all_oses_in_descending_order(os_descendents)
     end
 
     private
 
-    def load_all_oses(os_descendents)
-      os_descendents.each do |os|
+    def load_all_oses_in_descending_order(os_descendents)
+      os_descendents.reverse_each do |os|
         load_for_os(os)
       end
     end
@@ -34,15 +34,19 @@ module Facter
       classes.each do |class_name|
         fact_name = class_name::FACT_NAME
 
-        load_fact(fact_name, class_name)
+        # if fact is already loaded, skip it
+        next if @facts.select { |fact| fact.name == fact_name }.any?
+
+        type = fact_name.end_with?('.*') ? :legacy : :core
+        load_fact(fact_name, class_name, type)
         next unless class_name.const_defined?('ALIASES')
 
-        [*class_name::ALIASES].each { |fact_alias| load_fact(fact_alias, class_name) }
+        [*class_name::ALIASES].each { |fact_alias| load_fact(fact_alias, class_name, :legacy) }
       end
     end
 
-    def load_fact(fact_name, klass)
-      loaded_fact = LoadedFact.new(fact_name, klass)
+    def load_fact(fact_name, klass, type)
+      loaded_fact = LoadedFact.new(fact_name, klass, type)
       @facts << loaded_fact
     end
   end

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -232,6 +232,12 @@ describe Facter::InternalFactLoader do
         expect(internal_fact_loader.legacy_facts.size).to eq(1)
       end
 
+      it 'contains a wildcard at the end' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts.first.name).to end_with('.*')
+      end
+
       it 'loads no core facts' do
         internal_fact_loader = Facter::InternalFactLoader.new
 

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -166,5 +166,49 @@ describe Facter::InternalFactLoader do
         expect(internal_fact_loader.facts.first.klass).to eq(Facts::El::Path)
       end
     end
+
+    context 'when loading fact with aliases' do
+      before do
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
+          .to receive(:discover_classes)
+          .with(:Debian)
+          .and_return([Facts::Debian::Os::Name])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
+
+        stub_const('Facts::Debian::Os::Name::FACT_NAME', 'os.name')
+        stub_const('Facts::Debian::Os::Name::ALIASES', 'operatingsystem')
+      end
+
+      it 'loads two facts' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.size).to eq(2)
+      end
+
+      it 'loads one core fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.core_facts.size).to eq(1)
+      end
+
+      it 'loads one legacy fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts.size).to eq(1)
+      end
+
+      it 'loads a core fact with the fact name' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.core_facts.first.name).to eq('os.name')
+      end
+
+      it 'loads a legacy fact with the alias name' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts.first.name).to eq('operatingsystem')
+      end
+    end
   end
 end

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -7,22 +7,22 @@ describe Facter::InternalFactLoader do
 
   describe '#initialize' do
     context 'load facts' do
-      it 'loads one legacy fact and sees it as core' do
+      it 'loads one legacy fact' do
         allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return([:Windows])
         allow_any_instance_of(Facter::ClassDiscoverer)
           .to receive(:discover_classes)
           .with(:Windows)
           .and_return([Facts::Windows::NetworkInterfaces])
 
-        stub_const('Facter::Windows::NetworkInterfaces::FACT_NAME', 'network_.*')
+        stub_const('Facts::Windows::NetworkInterfaces::FACT_NAME', 'network_.*')
 
         internal_fact_loader = Facter::InternalFactLoader.new
         legacy_facts = internal_fact_loader.legacy_facts
         core_facts = internal_fact_loader.core_facts
 
-        expect(legacy_facts.size).to eq(0)
-        expect(core_facts.size).to eq(1)
-        expect(core_facts.first.type).to eq(:core)
+        expect(legacy_facts.size).to eq(1)
+        expect(core_facts.size).to eq(0)
+        expect(legacy_facts.first.type).to eq(:legacy)
       end
 
       it 'loads one core fact' do
@@ -31,12 +31,12 @@ describe Facter::InternalFactLoader do
           .with(:Debian)
           .and_return([Facts::Debian::Os::Name])
 
-        stub_const('Facter::Debian::OsName::FACT_NAME', 'os.name')
+        stub_const('Facts::Debian::OsName::FACT_NAME', 'os.name')
 
         internal_fact_loader = Facter::InternalFactLoader.new
         core_facts = internal_fact_loader.core_facts
 
-        expect(core_facts.size).to eq(2)
+        expect(core_facts.size).to eq(1)
         expect(core_facts.first.type).to eq(:core)
       end
 
@@ -46,18 +46,17 @@ describe Facter::InternalFactLoader do
         allow_any_instance_of(Facter::ClassDiscoverer)
           .to receive(:discover_classes)
           .with(:Windows)
-          .and_return([Facts::Windows::NetworkInterfaces, Facts::Windows::Os::Name])
+          .and_return([Facts::Windows::NetworkInterfaces, Facts::Windows::Path])
 
-        stub_const('Facter::Windows::NetworkInterface::FACT_NAME', 'network_.*')
-        stub_const('Facter::Windows::OsName::FACT_NAME', 'os.name')
+        stub_const('Facts::Windows::NetworkInterface::FACT_NAME', 'network_.*')
+        stub_const('Facts::Windows::OsName::FACT_NAME', 'path')
 
         internal_fact_loader = Facter::InternalFactLoader.new
         all_facts = internal_fact_loader.facts
 
-        expect(all_facts.size).to eq(3)
-        all_facts.each do |fact|
-          expect(fact.type).to eq(:core)
-        end
+        expect(all_facts.size).to eq(2)
+        expect(all_facts.find { |loaded_fact| loaded_fact.type == :core }.type).to eq(:core)
+        expect(all_facts.find { |loaded_fact| loaded_fact.type == :legacy }.type).to eq(:legacy)
       end
 
       it 'loads no facts' do
@@ -69,6 +68,45 @@ describe Facter::InternalFactLoader do
         all_facts_hash = internal_fact_loader.facts
 
         expect(all_facts_hash.size).to eq(0)
+      end
+    end
+
+    context 'load hierarchy of facts' do
+      before do
+        allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return(%i[Debian El])
+
+        allow_any_instance_of(Facter::ClassDiscoverer)
+          .to receive(:discover_classes)
+          .with(:Debian)
+          .and_return([Facts::Debian::Path])
+
+        allow_any_instance_of(Facter::ClassDiscoverer)
+          .to receive(:discover_classes)
+          .with(:El)
+          .and_return([Facts::El::Path])
+
+        stub_const('Facts::Debian::Path::FACT_NAME', 'path')
+        stub_const('Facts::El::Path::FACT_NAME', 'path')
+      end
+
+      let(:internal_fact_loader) { Facter::InternalFactLoader.new }
+
+      it 'loads one fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.size).to eq(1)
+      end
+
+      it 'loads path fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.first.name).to eq('path')
+      end
+
+      it 'loads only el path' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.first.klass).to eq(Facts::El::Path)
       end
     end
   end

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -2,17 +2,24 @@
 
 describe Facter::InternalFactLoader do
   before do
-    allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return([:Debian])
+    os_detector_mock = instance_double(OsDetector)
+    allow(os_detector_mock).to receive(:hierarchy).and_return([:Debian])
+    allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
   end
 
   describe '#initialize' do
-    context 'load facts' do
+    context 'when loading facts' do
       it 'loads one legacy fact' do
-        allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return([:Windows])
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        os_detector_mock = instance_double(OsDetector)
+        allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
+        allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
+
+        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
           .and_return([Facts::Windows::NetworkInterfaces])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
         stub_const('Facts::Windows::NetworkInterfaces::FACT_NAME', 'network_.*')
 
@@ -26,10 +33,12 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads one core fact' do
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
           .and_return([Facts::Debian::Os::Name])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
         stub_const('Facts::Debian::OsName::FACT_NAME', 'os.name')
 
@@ -41,12 +50,16 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads one legacy fact and one core fact' do
-        allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return([:Windows])
+        os_detector_mock = instance_double(OsDetector)
+        allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
+        allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
           .and_return([Facts::Windows::NetworkInterfaces, Facts::Windows::Path])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
         stub_const('Facts::Windows::NetworkInterface::FACT_NAME', 'network_.*')
         stub_const('Facts::Windows::OsName::FACT_NAME', 'path')
@@ -60,10 +73,13 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads no facts' do
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
           .and_return([])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
+
         internal_fact_loader = Facter::InternalFactLoader.new
         all_facts_hash = internal_fact_loader.facts
 
@@ -71,19 +87,22 @@ describe Facter::InternalFactLoader do
       end
     end
 
-    context 'load hierarchy of facts' do
+    context 'when loading hierarchy of facts' do
       before do
-        allow_any_instance_of(OsDetector).to receive(:hierarchy).and_return(%i[Debian El])
+        os_detector_mock = instance_double(OsDetector)
+        allow(os_detector_mock).to receive(:hierarchy).and_return(%i[Debian El])
+        allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
           .and_return([Facts::Debian::Path])
-
-        allow_any_instance_of(Facter::ClassDiscoverer)
+        allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:El)
           .and_return([Facts::El::Path])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
         stub_const('Facts::Debian::Path::FACT_NAME', 'path')
         stub_const('Facts::El::Path::FACT_NAME', 'path')

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 describe Facter::InternalFactLoader do
-  before do
-    os_detector_mock = instance_double(OsDetector)
-    allow(os_detector_mock).to receive(:hierarchy).and_return([:Debian])
-    allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
-  end
-
   describe '#initialize' do
-    context 'when loading facts' do
-      it 'loads one legacy fact' do
-        os_detector_mock = instance_double(OsDetector)
+    let(:os_detector_mock) { instance_spy(OsDetector) }
+
+    before do
+      allow(os_detector_mock).to receive(:hierarchy).and_return([:Debian])
+      allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
+    end
+
+    context 'when loading one legacy facts' do
+      before do
         allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
@@ -22,39 +22,64 @@ describe Facter::InternalFactLoader do
         allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
         stub_const('Facts::Windows::NetworkInterfaces::FACT_NAME', 'network_.*')
-
-        internal_fact_loader = Facter::InternalFactLoader.new
-        legacy_facts = internal_fact_loader.legacy_facts
-        core_facts = internal_fact_loader.core_facts
-
-        expect(legacy_facts.size).to eq(1)
-        expect(core_facts.size).to eq(0)
-        expect(legacy_facts.first.type).to eq(:legacy)
       end
 
-      it 'loads one core fact' do
-        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+      it 'loads no core facts' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.core_facts).to be_empty
+      end
+
+      it 'loads one legacy fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts.size).to eq(1)
+      end
+
+      it 'loads one fact with :legacy type' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts.first.type).to eq(:legacy)
+      end
+    end
+
+    context 'when loading one core fact' do
+      before do
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
-          .and_return([Facts::Debian::Os::Name])
+          .and_return([Facts::Debian::Path])
         allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
 
-        stub_const('Facts::Debian::OsName::FACT_NAME', 'os.name')
-
-        internal_fact_loader = Facter::InternalFactLoader.new
-        core_facts = internal_fact_loader.core_facts
-
-        expect(core_facts.size).to eq(1)
-        expect(core_facts.first.type).to eq(:core)
+        stub_const('Facts::Debian::Path::FACT_NAME', 'path')
       end
 
-      it 'loads one legacy fact and one core fact' do
-        os_detector_mock = instance_double(OsDetector)
+      it 'loads no legacy facts' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.legacy_facts).to be_empty
+      end
+
+      it 'loads one core fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.core_facts.size).to eq(1)
+      end
+
+      it 'loads one fact with :core type' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.core_facts.first.type).to eq(:core)
+      end
+    end
+
+    context 'when loading one legacy fact and one core fact' do
+      before do
         allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
@@ -63,37 +88,50 @@ describe Facter::InternalFactLoader do
 
         stub_const('Facts::Windows::NetworkInterface::FACT_NAME', 'network_.*')
         stub_const('Facts::Windows::OsName::FACT_NAME', 'path')
-
-        internal_fact_loader = Facter::InternalFactLoader.new
-        all_facts = internal_fact_loader.facts
-
-        expect(all_facts.size).to eq(2)
-        expect(all_facts.find { |loaded_fact| loaded_fact.type == :core }.type).to eq(:core)
-        expect(all_facts.find { |loaded_fact| loaded_fact.type == :legacy }.type).to eq(:legacy)
       end
 
-      it 'loads no facts' do
-        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+      it 'loads two fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.size).to eq(2)
+      end
+
+      it 'loads one legacy fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.count { |lf| lf.type == :legacy }).to eq(1)
+      end
+
+      it 'loads one core fact' do
+        internal_fact_loader = Facter::InternalFactLoader.new
+
+        expect(internal_fact_loader.facts.count { |lf| lf.type == :core }).to eq(1)
+      end
+    end
+
+    context 'when loading no facts' do
+      before do
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
           .and_return([])
         allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
+      end
 
+      it 'loads no facts' do
         internal_fact_loader = Facter::InternalFactLoader.new
-        all_facts_hash = internal_fact_loader.facts
 
-        expect(all_facts_hash.size).to eq(0)
+        expect(internal_fact_loader.facts).to be_empty
       end
     end
 
     context 'when loading hierarchy of facts' do
       before do
-        os_detector_mock = instance_double(OsDetector)
         allow(os_detector_mock).to receive(:hierarchy).and_return(%i[Debian El])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_double(Facter::ClassDiscoverer)
+        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -2,6 +2,8 @@
 
 describe Facter::InternalFactLoader do
   describe '#initialize' do
+    subject(:internal_fact_loader) { Facter::InternalFactLoader.new }
+
     let(:os_detector_mock) { instance_spy(OsDetector) }
     let(:class_discoverer_mock) { instance_spy(Facter::ClassDiscoverer) }
 
@@ -25,20 +27,14 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads no core facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts).to be_empty
       end
 
       it 'loads one legacy fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.size).to eq(1)
       end
 
       it 'loads one fact with :legacy type' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.first.type).to eq(:legacy)
       end
     end
@@ -55,20 +51,14 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads no legacy facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts).to be_empty
       end
 
       it 'loads one core fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts.size).to eq(1)
       end
 
       it 'loads one fact with :core type' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts.first.type).to eq(:core)
       end
     end
@@ -89,20 +79,14 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads two facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.size).to eq(2)
       end
 
       it 'loads one legacy fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.count { |lf| lf.type == :legacy }).to eq(1)
       end
 
       it 'loads one core fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.count { |lf| lf.type == :core }).to eq(1)
       end
     end
@@ -117,8 +101,6 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads no facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts).to be_empty
       end
     end
@@ -142,23 +124,15 @@ describe Facter::InternalFactLoader do
         stub_const('Facts::El::Path::FACT_NAME', 'path')
       end
 
-      let(:internal_fact_loader) { Facter::InternalFactLoader.new }
-
       it 'loads one fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.size).to eq(1)
       end
 
       it 'loads path fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.first.name).to eq('path')
       end
 
       it 'loads only el path' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.first.klass).to eq(Facts::El::Path)
       end
     end
@@ -176,32 +150,22 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads two facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.size).to eq(2)
       end
 
       it 'loads one core fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts.size).to eq(1)
       end
 
       it 'loads one legacy fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.size).to eq(1)
       end
 
       it 'loads a core fact with the fact name' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts.first.name).to eq('os.name')
       end
 
       it 'loads a legacy fact with the alias name' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.first.name).to eq('operatingsystem')
       end
     end
@@ -221,26 +185,18 @@ describe Facter::InternalFactLoader do
       end
 
       it 'loads one fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.facts.size).to eq(1)
       end
 
       it 'loads one legacy fact' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.size).to eq(1)
       end
 
       it 'contains a wildcard at the end' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.legacy_facts.first.name).to end_with('.*')
       end
 
       it 'loads no core facts' do
-        internal_fact_loader = Facter::InternalFactLoader.new
-
         expect(internal_fact_loader.core_facts).to be_empty
       end
     end

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -3,18 +3,18 @@
 describe Facter::InternalFactLoader do
   describe '#initialize' do
     let(:os_detector_mock) { instance_spy(OsDetector) }
+    let(:class_discoverer_mock) { instance_spy(Facter::ClassDiscoverer) }
 
     before do
       allow(os_detector_mock).to receive(:hierarchy).and_return([:Debian])
       allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
     end
 
-    context 'when loading one legacy facts' do
+    context 'when loading one legacy fact' do
       before do
         allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
@@ -45,7 +45,6 @@ describe Facter::InternalFactLoader do
 
     context 'when loading one core fact' do
       before do
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
@@ -79,7 +78,6 @@ describe Facter::InternalFactLoader do
         allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)
@@ -111,7 +109,6 @@ describe Facter::InternalFactLoader do
 
     context 'when loading no facts' do
       before do
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
@@ -131,7 +128,6 @@ describe Facter::InternalFactLoader do
         allow(os_detector_mock).to receive(:hierarchy).and_return(%i[Debian El])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
@@ -169,7 +165,6 @@ describe Facter::InternalFactLoader do
 
     context 'when loading fact with aliases' do
       before do
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Debian)
@@ -216,7 +211,6 @@ describe Facter::InternalFactLoader do
         allow(os_detector_mock).to receive(:hierarchy).and_return([:Windows])
         allow(OsDetector).to receive(:instance).and_return(os_detector_mock)
 
-        class_discoverer_mock = instance_spy(Facter::ClassDiscoverer)
         allow(class_discoverer_mock)
           .to receive(:discover_classes)
           .with(:Windows)

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -90,7 +90,7 @@ describe Facter::InternalFactLoader do
         stub_const('Facts::Windows::OsName::FACT_NAME', 'path')
       end
 
-      it 'loads two fact' do
+      it 'loads two facts' do
         internal_fact_loader = Facter::InternalFactLoader.new
 
         expect(internal_fact_loader.facts.size).to eq(2)


### PR DESCRIPTION
When having an OS hierarchy, we should start loading facts from the bottom of the hierarchy and only load facts one. The PR fixes fact_type for LoadedFacts as well.