### PR TITLE
(FACT-2512) Handle Raspbian as Debian

### DIFF
--- a/lib/facts/debian/os/distro/release.rb
+++ b/lib/facts/debian/os/distro/release.rb
@@ -27,7 +27,7 @@ module Facts
           def determine_release_for_os
             os_name = Facter::Resolvers::OsRelease.resolve(:name)
 
-            if os_name =~ /Debian/
+            if os_name =~ /Debian|Raspbian/
               Facter::Resolvers::DebianVersion.resolve(:version)
             else
               Facter::Resolvers::OsRelease.resolve(:version_id)

--- a/lib/facts/debian/os/release.rb
+++ b/lib/facts/debian/os/release.rb
@@ -29,7 +29,7 @@ module Facts
         def determine_release_for_os
           os_name = Facter::Resolvers::OsRelease.resolve(:name)
 
-          if os_name =~ /Debian/
+          if os_name =~ /Debian|Raspbian/
             Facter::Resolvers::DebianVersion.resolve(:version)
           else
             Facter::Resolvers::OsRelease.resolve(:version_id)

--- a/lib/framework/detector/os_detector.rb
+++ b/lib/framework/detector/os_detector.rb
@@ -54,6 +54,8 @@ class OsDetector
       %w[Debian]
     when :elementary
       %w[Debian]
+    when :raspbian
+      %w[Debian]
     when :fedora
       %w[El]
     when :amzn


### PR DESCRIPTION
This change makes facter run on a Raspbian distro.

The new os facts reported:


```
os => {
  architecture => "armv7l",
  distro => {
    codename => "stretch",
    description => "Raspbian GNU/Linux 9.11 (stretch)",
    id => "Raspbian",
    release => {
      full => "9.11",
      major => "9",
      minor => "11"
    }
  },
  family => "Debian",
  hardware => "armv7l",
  name => "Raspbian",
  release => {
    full => "9.11",
    major => "9",
    minor => "11"
  },
  selinux => {
    enabled => false
  }
}
```