### PR TITLE
(FACT-2477) Collect facts from alternative sources

### DIFF
--- a/lib/facts/debian/lsbdistcodename.rb
+++ b/lib/facts/debian/lsbdistcodename.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Debian
+    class Lsbdistcodename
+      FACT_NAME = 'lsbdistcodename'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facts/debian/lsbdistdescription.rb
+++ b/lib/facts/debian/lsbdistdescription.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Debian
+    class Lsbdistdescription
+      FACT_NAME = 'lsbdistdescription'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facts/debian/lsbdistid.rb
+++ b/lib/facts/debian/lsbdistid.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Facts
+  module Debian
+    class Lsbdistid
+      FACT_NAME = 'lsbdistid'
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+
+        Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy)
+      end
+    end
+  end
+end

--- a/lib/facts/debian/lsbdistrelease.rb
+++ b/lib/facts/debian/lsbdistrelease.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Facts
+  module Debian
+    class Lsbdistrelease
+      FACT_NAME = 'lsbdistrelease'
+      ALIASES = %w[lsbmajdistrelease lsbminordistrelease].freeze
+      TYPE = :legacy
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::LsbRelease.resolve(:release)
+
+        return Facter::ResolvedFact.new(FACT_NAME, nil, :legacy) unless fact_value
+
+        version = fact_value.split('.')
+
+        [Facter::ResolvedFact.new(FACT_NAME, fact_value, :legacy),
+         Facter::ResolvedFact.new(ALIASES[0], version[0], :legacy),
+         Facter::ResolvedFact.new(ALIASES[1], version[1], :legacy)]
+      end
+    end
+  end
+end

--- a/lib/facts/debian/os/distro/codename.rb
+++ b/lib/facts/debian/os/distro/codename.rb
@@ -6,13 +6,22 @@ module Facts
       module Distro
         class Codename
           FACT_NAME = 'os.distro.codename'
-          ALIASES = 'lsbdistcodename'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:codename)
+            fact_value = Facter::Resolvers::OsRelease.resolve(:version_codename)
+            fact_value ||= retreieve_from_version
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
+          end
+
+          def retreieve_from_version
+            version = Facter::Resolvers::OsRelease.resolve(:version)
+            return unless version
+
+            codename = /\(.*\)$/.match(version).to_s.gsub(/\(|\)/, '')
+            return codename unless codename.empty?
+
+            /[A-Za-z]+\s[A-Za-z]+/.match(version).to_s.split(' ').first.downcase
           end
         end
       end

--- a/lib/facts/debian/os/distro/description.rb
+++ b/lib/facts/debian/os/distro/description.rb
@@ -6,13 +6,11 @@ module Facts
       module Distro
         class Description
           FACT_NAME = 'os.distro.description'
-          ALIASES = 'lsbdistdescription'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:description)
+            fact_value = Facter::Resolvers::OsRelease.resolve(:pretty_name)
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facts/debian/os/distro/id.rb
+++ b/lib/facts/debian/os/distro/id.rb
@@ -6,13 +6,11 @@ module Facts
       module Distro
         class Id
           FACT_NAME = 'os.distro.id'
-          ALIASES = 'lsbdistid'
 
           def call_the_resolver
-            fact_value = Facter::Resolvers::LsbRelease.resolve(:distributor_id)
+            fact_value = Facter::Resolvers::OsRelease.resolve(:id).capitalize
 
-            [Facter::ResolvedFact.new(FACT_NAME, fact_value),
-             Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, fact_value)
           end
         end
       end

--- a/lib/facts/debian/os/distro/release.rb
+++ b/lib/facts/debian/os/distro/release.rb
@@ -6,7 +6,6 @@ module Facts
       module Distro
         class Release
           FACT_NAME = 'os.distro.release'
-          ALIASES = %w[lsbdistrelease lsbmajdistrelease lsbminordistrelease].freeze
 
           def call_the_resolver
             fact_value = determine_release_for_os
@@ -16,10 +15,7 @@ module Facts
             versions = fact_value.split('.')
             release = { 'full' => fact_value, 'major' => versions[0], 'minor' => versions[1].gsub(/^0([1-9])/, '\1') }
 
-            [Facter::ResolvedFact.new(FACT_NAME, release),
-             Facter::ResolvedFact.new(ALIASES[0], fact_value, :legacy),
-             Facter::ResolvedFact.new(ALIASES[1], release['major'], :legacy),
-             Facter::ResolvedFact.new(ALIASES[2], release['minor'], :legacy)]
+            Facter::ResolvedFact.new(FACT_NAME, release)
           end
 
           private

--- a/spec/facter/facts/debian/lsbdistcodename_spec.rb
+++ b/spec/facter/facts/debian/lsbdistcodename_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Debian::Lsbdistcodename do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Debian::Lsbdistcodename.new }
+
+    let(:value) { 'stretch' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    end
+
+    it 'returns lsbdistcodename fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistcodename', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/debian/lsbdistdescription_spec.rb
+++ b/spec/facter/facts/debian/lsbdistdescription_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Debian::Lsbdistdescription do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Debian::Lsbdistdescription.new }
+
+    let(:value) { 'stretch' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+    end
+
+    it 'returns lsbdistdescription fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistdescription', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/debian/lsbdistid_spec.rb
+++ b/spec/facter/facts/debian/lsbdistid_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Facts::Debian::Lsbdistid do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Debian::Lsbdistid.new }
+
+    let(:value) { 'stretch' }
+
+    before do
+      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+    end
+
+    it 'calls Facter::Resolvers::LsbRelease' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+    end
+
+    it 'returns lsbdistid fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'lsbdistid', value: value, type: :legacy)
+    end
+  end
+end

--- a/spec/facter/facts/debian/lsbdistrelease_spec.rb
+++ b/spec/facter/facts/debian/lsbdistrelease_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+describe Facts::Debian::Lsbdistrelease do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Debian::Lsbdistrelease.new }
+
+    context 'when lsb-release is installed' do
+      before do
+        allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:release).and_return(value)
+      end
+
+      context 'when version_id is retrieved successful' do
+        let(:value) { '18.04' }
+        let(:value_final) { { 'full' => '18.04', 'major' => '18', 'minor' => '04' } }
+
+        it 'calls Facter::Resolvers::LsbRelease with :name' do
+          fact.call_the_resolver
+          expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+        end
+
+        it 'returns release fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+            contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
+                            an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                        value: value_final['major'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbminordistrelease',
+                                                        value: value_final['minor'], type: :legacy))
+        end
+      end
+
+      context 'when Debian 10' do
+        let(:value) { '10' }
+        let(:value_final) { { 'full' => '10', 'major' => '10', 'minor' => nil } }
+
+        it 'calls Facter::Resolvers::LsbRelease with :name' do
+          fact.call_the_resolver
+          expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:release)
+        end
+
+        it 'returns release fact' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+            contain_exactly(an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
+                            an_object_having_attributes(name: 'lsbmajdistrelease',
+                                                        value: value_final['major'], type: :legacy),
+                            an_object_having_attributes(name: 'lsbminordistrelease',
+                                                        value: value_final['minor'], type: :legacy))
+        end
+      end
+
+      context 'when lsb-release is not installed' do
+        let(:value) { nil }
+
+        it 'returns release fact as nil' do
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'lsbdistrelease', value: value, type: :legacy)
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/debian/os/distro/codename_spec.rb
+++ b/spec/facter/facts/debian/os/distro/codename_spec.rb
@@ -4,21 +4,100 @@ describe Facts::Debian::Os::Distro::Codename do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Debian::Os::Distro::Codename.new }
 
-    let(:value) { 'stretch' }
+    context 'when version codename exists in os-release' do
+      let(:value) { 'stretch' }
 
-    before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:codename).and_return(value)
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_codename).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_codename)
+      end
+
+      it 'returns os.distro.codename fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: value)
+      end
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:codename)
+    context 'when version codename does not exists in os-release on Ubuntu' do
+      let(:value) { nil }
+      let(:version) { '14.04.2 LTS, Trusty Tahr' }
+      let(:result) { 'trusty' }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_codename).and_return(value)
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version).and_return(version)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version_codename' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_codename)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version)
+      end
+
+      it 'returns os.distro.codename fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: result)
+      end
     end
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.codename', value: value),
-                        an_object_having_attributes(name: 'lsbdistcodename', value: value, type: :legacy))
+    context 'when version codename does not exists in os-release on Debian' do
+      let(:value) { nil }
+      let(:version) { '9 (stretch)' }
+      let(:result) { 'stretch' }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_codename).and_return(value)
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version).and_return(version)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version_codename' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_codename)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version)
+      end
+
+      it 'returns os.distro.codename fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: result)
+      end
+    end
+
+    context 'when version codename and version do not exist in os-release' do
+      let(:value) { nil }
+      let(:version) { nil }
+      let(:result) { nil }
+
+      before do
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_codename).and_return(value)
+        allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version).and_return(version)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version_codename' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_codename)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version)
+      end
+
+      it 'returns os.distro.codename fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+          have_attributes(name: 'os.distro.codename', value: result)
+      end
     end
   end
 end

--- a/spec/facter/facts/debian/os/distro/description_spec.rb
+++ b/spec/facter/facts/debian/os/distro/description_spec.rb
@@ -7,18 +7,17 @@ describe Facts::Debian::Os::Distro::Description do
     let(:value) { 'Debian GNU/Linux 9.0 (stretch)' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:description).and_return(value)
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:pretty_name).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::OsRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:description)
+      expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:pretty_name)
     end
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.description', value: value),
-                        an_object_having_attributes(name: 'lsbdistdescription', value: value, type: :legacy))
+    it 'returns os.distro.description fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.description', value: value)
     end
   end
 end

--- a/spec/facter/facts/debian/os/distro/id_spec.rb
+++ b/spec/facter/facts/debian/os/distro/id_spec.rb
@@ -4,21 +4,20 @@ describe Facts::Debian::Os::Distro::Id do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Debian::Os::Distro::Id.new }
 
-    let(:value) { 'Debian' }
+    let(:value) { 'debian' }
 
     before do
-      allow(Facter::Resolvers::LsbRelease).to receive(:resolve).with(:distributor_id).and_return(value)
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:id).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::LsbRelease' do
+    it 'calls Facter::Resolvers::OsRelease' do
       fact.call_the_resolver
-      expect(Facter::Resolvers::LsbRelease).to have_received(:resolve).with(:distributor_id)
+      expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:id)
     end
 
-    it 'returns release fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.distro.id', value: value),
-                        an_object_having_attributes(name: 'lsbdistid', value: value, type: :legacy))
+    it 'returns os.distro.id fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'os.distro.id', value: value.capitalize)
     end
   end
 end

--- a/spec/facter/facts/debian/os/distro/release_spec.rb
+++ b/spec/facter/facts/debian/os/distro/release_spec.rb
@@ -27,13 +27,8 @@ describe Facts::Debian::Os::Distro::Release do
         end
 
         it 'returns release fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: value_final),
-                            an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                            an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                        value: value_final['major'], type: :legacy),
-                            an_object_having_attributes(name: 'lsbminordistrelease',
-                                                        value: value_final['minor'], type: :legacy))
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.distro.release', value: value_final)
         end
       end
 
@@ -70,13 +65,8 @@ describe Facts::Debian::Os::Distro::Release do
         end
 
         it 'returns release fact' do
-          expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-            contain_exactly(an_object_having_attributes(name: 'os.distro.release', value: value_final),
-                            an_object_having_attributes(name: 'lsbdistrelease', value: value, type: :legacy),
-                            an_object_having_attributes(name: 'lsbmajdistrelease',
-                                                        value: value_final['major'], type: :legacy),
-                            an_object_having_attributes(name: 'lsbminordistrelease',
-                                                        value: value_final['minor'], type: :legacy))
+          expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+            have_attributes(name: 'os.distro.release', value: value_final)
         end
       end
 

--- a/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/internal_fact_loader_spec.rb
@@ -200,5 +200,33 @@ describe Facter::InternalFactLoader do
         expect(internal_fact_loader.core_facts).to be_empty
       end
     end
+
+    context 'when loading legacy fact without wildcard' do
+      before do
+        allow(class_discoverer_mock)
+          .to receive(:discover_classes)
+          .with(:Debian)
+          .and_return([Facts::Debian::Lsbdistid])
+        allow(Facter::ClassDiscoverer).to receive(:instance).and_return(class_discoverer_mock)
+
+        stub_const('Facts::Debian::Lsbdistid::FACT_NAME', 'lsbdistid')
+      end
+
+      it 'loads one fact' do
+        expect(internal_fact_loader.facts.size).to eq(1)
+      end
+
+      it 'loads one legacy fact' do
+        expect(internal_fact_loader.legacy_facts.size).to eq(1)
+      end
+
+      it 'does not contain a wildcard at the end' do
+        expect(internal_fact_loader.legacy_facts.first.name).not_to end_with('.*')
+      end
+
+      it 'loads no core facts' do
+        expect(internal_fact_loader.core_facts).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Collect Debian os.distro facts from /etc/os-release instead of using lsb-release. Only lsb* legacy facts will be resolved using lsb-release.