### PR TITLE
(FACT-2528) Fix for tests/facts/ssh_key.rb

### DIFF
--- a/lib/framework/parsers/query_parser.rb
+++ b/lib/framework/parsers/query_parser.rb
@@ -71,7 +71,7 @@ module Facter
       end
 
       def found_fact?(fact_name, query_fact)
-        fact_with_wildcard = fact_name.include?('.*')
+        fact_with_wildcard = fact_name.include?('.*') && !query_fact.include?('.')
 
         return false if fact_with_wildcard && !query_fact.match("^#{fact_name}$")
 

--- a/spec/facter/query_parser_spec.rb
+++ b/spec/facter/query_parser_spec.rb
@@ -47,6 +47,22 @@ describe Facter::QueryParser do
         contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: networking_class)))
     end
 
+    it 'creates a searched fact correctly without name collision' do
+      query_list = ['ssh.rsa.key']
+
+      ssh_class = 'Facter::El::Ssh'
+      ssh_key_class = 'Facter::El::Sshalgorithmkey'
+
+      loaded_fact_ssh_key = instance_spy(Facter::LoadedFact, name: 'ssh.*key', klass: ssh_key_class, type: :legacy)
+      loaded_fact_ssh = instance_spy(Facter::LoadedFact, name: 'ssh', klass: ssh_class, type: :core)
+      loaded_facts = [loaded_fact_ssh_key, loaded_fact_ssh]
+
+      matched_facts = Facter::QueryParser.parse(query_list, loaded_facts)
+
+      expect(matched_facts).to be_an_instance_of(Array).and \
+        contain_exactly(an_instance_of(Facter::SearchedFact).and(having_attributes(fact_class: ssh_class)))
+    end
+
     it 'creates one custom searched fact' do
       query_list = ['custom_fact']
       os_name_class = 'Facter::Ubuntu::OsName'


### PR DESCRIPTION
Description of the problem: when user query is ssh.rsa.key, the resulted SearchedFact was legacy fact Sshalgorithmkey (name: ssh.*key) instead of the core fact Ssh

Fix: don't consider legacy facts for Searched Fact when user query contains "."