### PR TITLE
(FACT-2564) Add support for zpool_featureflags and fix zpool_version

### DIFF
--- a/lib/facts/solaris/zpool_featureflags.rb
+++ b/lib/facts/solaris/zpool_featureflags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Facts
+  module Solaris
+    class ZpoolFeatureflags
+      FACT_NAME = 'zpool_featureflags'
+
+      def call_the_resolver
+        fact_value = Facter::Resolvers::Solaris::ZPool.resolve(:zpool_featureflags)
+        Facter::ResolvedFact.new(FACT_NAME, fact_value)
+      end
+    end
+  end
+end

--- a/lib/resolvers/solaris/zpool_resolver.rb
+++ b/lib/resolvers/solaris/zpool_resolver.rb
@@ -22,11 +22,13 @@ module Facter
           def build_zpool_facts
             output, _status = Open3.capture2('zpool upgrade -v')
             features_list = output.scan(/^\s+(\d+)/).flatten
+            features_flags = output.scan(/^([a-z0-9_]+)[[:blank:]]*(\(read-only compatible\))?$/).map(&:first)
 
             return if features_list.empty?
 
             @fact_list[:zpool_featurenumbers] = features_list.join(',')
-            @fact_list[:zpool_version] = features_list.last
+            @fact_list[:zpool_featureflags] = features_flags.join(',')
+            @fact_list[:zpool_version] = features_flags.any? ? '5000' : features_list.last
           end
         end
       end

--- a/spec/facter/facts/solaris/zpool_featureflags_spec.rb
+++ b/spec/facter/facts/solaris/zpool_featureflags_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe Facts::Solaris::ZpoolFeatureflags do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Solaris::ZpoolFeatureflags.new }
+
+    let(:zpool_feature_flags) { 'async_destroy,empty_bpobj,lz4_compress,multi_vdev_crash_dump,spacemap_histogram' }
+
+    before do
+      allow(Facter::Resolvers::Solaris::ZPool).to \
+        receive(:resolve).with(:zpool_featureflags).and_return(zpool_feature_flags)
+    end
+
+    it 'calls Facter::Resolvers::Solaris::ZPool' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Solaris::ZPool).to have_received(:resolve).with(:zpool_featureflags)
+    end
+
+    it 'returns the zpool_featureflags fact' do
+      expect(fact.call_the_resolver).to be_an_instance_of(Facter::ResolvedFact).and \
+        have_attributes(name: 'zpool_featureflags', value: zpool_feature_flags)
+    end
+  end
+end

--- a/spec/facter/resolvers/solaris/zpool_resolver_spec.rb
+++ b/spec/facter/resolvers/solaris/zpool_resolver_spec.rb
@@ -31,6 +31,11 @@ describe Facter::Resolvers::Solaris::ZPool do
 
     context 'when zpool has featureflags' do
       let(:output) { load_fixture('zpool-with-featureflags').read }
+      let(:zpool_featureflags) do
+        'async_destroy,empty_bpobj,lz4_compress,multi_vdev_crash_dump,spacemap_histogram,enabled_txg,' \
+        'hole_birth,extensible_dataset,embedded_data,bookmarks,filesystem_limits,large_blocks,large_dnode,' \
+        'sha512,skein,device_removal,obsolete_counts,zpool_checkpoint,spacemap_v2'
+      end
 
       it 'returns zpool version fact' do
         result = Facter::Resolvers::Solaris::ZPool.resolve(:zpool_version)
@@ -39,10 +44,7 @@ describe Facter::Resolvers::Solaris::ZPool do
 
       it 'returns zpool featureflags fact' do
         result = Facter::Resolvers::Solaris::ZPool.resolve(:zpool_featureflags)
-        expect(result).to eq('async_destroy,empty_bpobj,lz4_compress,multi_vdev_crash_dump,' \
-          'spacemap_histogram,enabled_txg,hole_birth,extensible_dataset,embedded_data,bookmarks,' \
-          'filesystem_limits,large_blocks,large_dnode,sha512,skein,device_removal,obsolete_counts,' \
-          'zpool_checkpoint,spacemap_v2')
+        expect(result).to eq(zpool_featureflags)
       end
     end
   end

--- a/spec/facter/resolvers/solaris/zpool_resolver_spec.rb
+++ b/spec/facter/resolvers/solaris/zpool_resolver_spec.rb
@@ -28,6 +28,23 @@ describe Facter::Resolvers::Solaris::ZPool do
       expect(result).to eq('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,' \
         '24,25,26,27,28,29,30,31,32,33,34')
     end
+
+    context 'when zpool has featureflags' do
+      let(:output) { load_fixture('zpool-with-featureflags').read }
+
+      it 'returns zpool version fact' do
+        result = Facter::Resolvers::Solaris::ZPool.resolve(:zpool_version)
+        expect(result).to eq('5000')
+      end
+
+      it 'returns zpool featureflags fact' do
+        result = Facter::Resolvers::Solaris::ZPool.resolve(:zpool_featureflags)
+        expect(result).to eq('async_destroy,empty_bpobj,lz4_compress,multi_vdev_crash_dump,' \
+          'spacemap_histogram,enabled_txg,hole_birth,extensible_dataset,embedded_data,bookmarks,' \
+          'filesystem_limits,large_blocks,large_dnode,sha512,skein,device_removal,obsolete_counts,' \
+          'zpool_checkpoint,spacemap_v2')
+      end
+    end
   end
 
   context 'when zpool command is not found' do

--- a/spec/fixtures/zpool-with-featureflags
+++ b/spec/fixtures/zpool-with-featureflags
@@ -1,0 +1,81 @@
+This system supports ZFS pool feature flags.
+
+The following features are supported:
+
+FEAT DESCRIPTION
+-------------------------------------------------------------
+async_destroy                         (read-only compatible)
+     Destroy filesystems asynchronously.
+empty_bpobj                           (read-only compatible)
+     Snapshots use less space.
+lz4_compress                         
+     LZ4 compression algorithm support.
+multi_vdev_crash_dump                
+     Crash dumps to multiple vdev pools.
+spacemap_histogram                    (read-only compatible)
+     Spacemaps maintain space histograms.
+enabled_txg                           (read-only compatible)
+     Record txg at which a feature is enabled
+hole_birth                           
+     Retain hole birth txg for more precise zfs send
+extensible_dataset                   
+     Enhanced dataset functionality, used by other features.
+embedded_data                        
+     Blocks which compress very well use even less space.
+bookmarks                             (read-only compatible)
+     "zfs bookmark" command
+filesystem_limits                     (read-only compatible)
+     Filesystem and snapshot limits.
+large_blocks                         
+     Support for blocks larger than 128KB.
+large_dnode                          
+     Variable on-disk size of dnodes.
+sha512                               
+     SHA-512/256 hash algorithm.
+skein                                
+     Skein hash algorithm.
+device_removal                       
+     Top-level vdevs can be removed, reducing logical pool size.
+obsolete_counts                       (read-only compatible)
+     Reduce memory used by removed devices when their blocks are freed or remapped.
+zpool_checkpoint                      (read-only compatible)
+     Pool state can be checkpointed, allowing rewind later.
+spacemap_v2                           (read-only compatible)
+     Space maps representing large segments are more efficient.
+
+The following legacy versions are also supported:
+
+VER  DESCRIPTION
+---  --------------------------------------------------------
+ 1   Initial ZFS version
+ 2   Ditto blocks (replicated metadata)
+ 3   Hot spares and double parity RAID-Z
+ 4   zpool history
+ 5   Compression using the gzip algorithm
+ 6   bootfs pool property
+ 7   Separate intent log devices
+ 8   Delegated administration
+ 9   refquota and refreservation properties
+ 10  Cache devices
+ 11  Improved scrub performance
+ 12  Snapshot properties
+ 13  snapused property
+ 14  passthrough-x aclinherit
+ 15  user/group space accounting
+ 16  stmf property support
+ 17  Triple-parity RAID-Z
+ 18  Snapshot user holds
+ 19  Log device removal
+ 20  Compression using zle (zero-length encoding)
+ 21  Deduplication
+ 22  Received properties
+ 23  Slim ZIL
+ 24  System attributes
+ 25  Improved scrub stats
+ 26  Improved snapshot deletion performance
+ 27  Improved snapshot creation performance
+ 28  Multiple vdev replacements
+
+For more information on a particular version, including supported releases,
+see the ZFS Administration Guide.
+


### PR DESCRIPTION
This allows facter-ng to return the same facts as facter 3.x.

This changes took place in facter 3.8.0 and was discussed here:
https://github.com/puppetlabs/facter/pull/1597