### PR TITLE
Add os.release facts on FreeBSD

### DIFF
--- a/lib/facts/freebsd/os/release.rb
+++ b/lib/facts/freebsd/os/release.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          installed_userland = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:installed_userland)
+
+          value = build_release_hash_from_version(installed_userland)
+
+          [Facter::ResolvedFact.new(FACT_NAME, value),
+           Facter::ResolvedFact.new(ALIASES.first, value[:major], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, installed_userland, :legacy)]
+        end
+
+        private
+
+        def build_release_hash_from_version(version_string)
+          version, branch_value = version_string.split('-', 2)
+          major_value, minor_value = version.split('.')
+          patchlevel_value = branch_value.split('-p')[1]
+
+          value = {
+            full: version_string,
+            major: major_value,
+            branch: branch_value
+          }
+
+          value[:minor] = minor_value if minor_value
+          value[:patchlevel] = patchlevel_value if patchlevel_value
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/facts/freebsd/os/release.rb
+++ b/lib/facts/freebsd/os/release.rb
@@ -10,7 +10,7 @@ module Facts
         def call_the_resolver
           installed_userland = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:installed_userland)
 
-          return [] if installed_userland.nil?
+          return Facter::ResolvedFact.new(FACT_NAME, nil) if !installed_userland || installed_userland.empty?
 
           value = build_release_hash_from_version(installed_userland)
 

--- a/lib/facts/freebsd/os/release.rb
+++ b/lib/facts/freebsd/os/release.rb
@@ -10,6 +10,8 @@ module Facts
         def call_the_resolver
           installed_userland = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:installed_userland)
 
+          return [] if installed_userland.nil?
+
           value = build_release_hash_from_version(installed_userland)
 
           [Facter::ResolvedFact.new(FACT_NAME, value),

--- a/lib/framework/detector/os_detector.rb
+++ b/lib/framework/detector/os_detector.rb
@@ -23,6 +23,8 @@ class OsDetector
                    :macosx
                  when /linux/
                    detect_distro
+                 when /freebsd/
+                   :freebsd
                  when /bsd/
                    :bsd
                  when /solaris/

--- a/lib/resolvers/freebsd/freebsd_version_resolver.rb
+++ b/lib/resolvers/freebsd/freebsd_version_resolver.rb
@@ -15,11 +15,14 @@ module Facter
           end
 
           def freebsd_version_system_call(fact_name)
-            output, _status = Open3.capture2('/bin/freebsd-version -kru')
+            output, _stderr, status = Open3.capture3('/bin/freebsd-version -kru')
+            return nil unless status.success?
 
             build_fact_list(output)
 
             @fact_list[fact_name]
+          rescue Errno::ENOENT
+            nil
           end
 
           def build_fact_list(output)

--- a/lib/resolvers/freebsd/freebsd_version_resolver.rb
+++ b/lib/resolvers/freebsd/freebsd_version_resolver.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class FreebsdVersion < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+
+        class << self
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { freebsd_version_system_call(fact_name) }
+          end
+
+          def freebsd_version_system_call(fact_name)
+            output, _status = Open3.capture2('/bin/freebsd-version -kru')
+
+            build_fact_list(output)
+
+            @fact_list[fact_name]
+          end
+
+          def build_fact_list(output)
+            freebsd_version_results = output.split("\n")
+
+            @fact_list[:installed_kernel]   = freebsd_version_results[0].strip
+            @fact_list[:running_kernel]     = freebsd_version_results[1].strip
+            @fact_list[:installed_userland] = freebsd_version_results[2].strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/os_hierarchy.json
+++ b/os_hierarchy.json
@@ -24,7 +24,11 @@
   },
   {
     "Solaris": [
-      "Bsd"
+      {
+        "Bsd": [
+          "Freebsd"
+        ]
+      }
     ]
   },
   "Macosx",

--- a/spec/facter/facts/freebsd/os/release_spec.rb
+++ b/spec/facter/facts/freebsd/os/release_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Freebsd::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::Freebsd::FreebsdVersion).to receive(:resolve).with(:installed_userland).and_return(value)
+    end
+
+    context 'when FreeBSD RELEASE' do
+      let(:value) { '12.1-RELEASE-p3' }
+
+      it 'calls Facter::Resolvers::Freebsd::FreebsdVersion' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Freebsd::FreebsdVersion).to have_received(:resolve).with(:installed_userland)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: { 'full' => value,
+                                                                                   'major' => '12',
+                                                                                   'minor' => '1',
+                                                                                   'branch' => 'RELEASE-p3',
+                                                                                   'patchlevel' => '3' }),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease', value: '12',
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease', value: value, type: :legacy))
+      end
+    end
+
+    context 'when FreeBSD STABLE' do
+      let(:value) { '12.1-STABLE' }
+
+      it 'calls Facter::Resolvers::Freebsd::FreebsdVersion' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Freebsd::FreebsdVersion).to have_received(:resolve).with(:installed_userland)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: { 'full' => value,
+                                                                                   'major' => '12',
+                                                                                   'minor' => '1',
+                                                                                   'branch' => 'STABLE' }),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease', value: '12',
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease', value: value, type: :legacy))
+      end
+    end
+
+    context 'when FreeBSD CURRENT' do
+      let(:value) { '13-CURRENT' }
+
+      it 'calls Facter::Resolvers::Freebsd::FreebsdVersion' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Freebsd::FreebsdVersion).to have_received(:resolve).with(:installed_userland)
+      end
+
+      it 'returns release fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: { 'full' => value,
+                                                                                   'major' => '13',
+                                                                                   'branch' => 'CURRENT' }),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease', value: '13',
+                                                      type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease', value: value, type: :legacy))
+      end
+    end
+  end
+end

--- a/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::FreebsdVersion do
+  before do
+    allow(Open3).to receive(:capture2)
+      .with('/bin/freebsd-version -kru')
+      .and_return('13.0-CURRENT
+        12.1-RELEASE-p3
+        12.0-STABLE')
+  end
+
+  it 'returns installed kernel' do
+    result = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:installed_kernel)
+
+    expect(result).to eq('13.0-CURRENT')
+  end
+
+  it 'returns running kernel' do
+    result = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:running_kernel)
+
+    expect(result).to eq('12.1-RELEASE-p3')
+  end
+
+  it 'returns installed userland' do
+    result = Facter::Resolvers::Freebsd::FreebsdVersion.resolve(:installed_userland)
+
+    expect(result).to eq('12.0-STABLE')
+  end
+end

--- a/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/freebsd_version_resolver_spec.rb
@@ -2,11 +2,13 @@
 
 describe Facter::Resolvers::Freebsd::FreebsdVersion do
   before do
-    allow(Open3).to receive(:capture2)
+    status = instance_double('Process::Status')
+    allow(status).to receive(:success?).and_return(true)
+    allow(Open3).to receive(:capture3)
       .with('/bin/freebsd-version -kru')
-      .and_return('13.0-CURRENT
+      .and_return(['13.0-CURRENT
         12.1-RELEASE-p3
-        12.0-STABLE')
+        12.0-STABLE', nil, status])
   end
 
   it 'returns installed kernel' do

--- a/spec/facter/resolvers/utils/windows/network_utils_spec.rb
+++ b/spec/facter/resolvers/utils/windows/network_utils_spec.rb
@@ -34,9 +34,6 @@ describe NetworkUtils do
       let(:address) { double(FFI::MemoryPointer) }
       let(:error) { 0 }
 
-      before do
-      end
-
       it 'returns an address' do
         expect(NetworkUtils.address_to_string(addr)).to eql('10.123.0.2')
       end


### PR DESCRIPTION
This PR provide support for Facter 3.x `os.release` facts on FreeBSD to Facter 4:

Before:
```sh-session
romain@zappy ~/Projects/facter-ng % bundle exec bin/facter os        
cat: /etc/release: No such file or directory
[2020-04-29 18:51:23.841325 ] ERROR Facter::Resolvers::SolarisRelease - Could not build release fact because of missing or empty file /etc/release 
cat: /etc/release: No such file or directory
[2020-04-29 18:51:23.842256 ] ERROR Facter::Resolvers::SolarisRelease - Could not build release fact because of missing or empty file /etc/release 
cat: /etc/release: No such file or directory
[2020-04-29 18:51:23.843051 ] ERROR Facter::Resolvers::SolarisRelease - Could not build release fact because of missing or empty file /etc/release 
{
  architecture => "amd64",
  family => "FreeBSD",
  hardware => "amd64",
  name => "FreeBSD",
  release => {
    full => null,
    major => null,
    minor => null
  }
}
```

After:
```sh-session
romain@zappy ~/Projects/facter-ng % bundle exec bin/facter os      
{
  architecture => "amd64",
  family => "FreeBSD",
  hardware => "amd64",
  name => "FreeBSD",
  release => {
    branch => "RELEASE-p4",
    full => "12.1-RELEASE-p4",
    major => "12",
    minor => "1",
    patchlevel => "4"
  }
}
```

Compare to:

```sh-session
romain@zappy ~/Projects/facter-ng % facter os
{
  architecture => "amd64",
  family => "FreeBSD",
  hardware => "amd64",
  name => "FreeBSD",
  release => {
    branch => "RELEASE-p4",
    full => "12.1-RELEASE-p4",
    major => "12",
    minor => "1",
    patchlevel => "4"
  }
}
```