### PR TITLE
(FACT-2420) partial fix for verify_partial_doubles

### DIFF
--- a/lib/custom_facts/core/execution.rb
+++ b/lib/custom_facts/core/execution.rb
@@ -51,7 +51,14 @@ module Facter
       # @param path [String] the path to check
       # @param platform [:posix,:windows,nil] the platform logic to use
       def absolute_path?(path, platform = nil)
-        @@impl.absolute_path?(path, platform)
+        case platform
+        when :posix
+          Facter::Core::Execution::Posix.new.absolute_path?(path)
+        when :windows
+          Facter::Core::Execution::Windows.new.absolute_path?(path)
+        else
+          @@impl.absolute_path?(path)
+        end
       end
 
       # Given a command line, this returns the command line with the

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -239,8 +239,7 @@ module Facter
     #
     # @api private
     def to_user_output(cli_options, *args)
-      cli_options = cli_options.map { |(k, v)| [k.to_sym, v] }.to_h
-      Facter::Options.init_from_cli(cli_options, args)
+      init_cli_options(cli_options)
       logger.info("executed with command line: #{ARGV.drop(1).join(' ')}")
       log_blocked_facts
 
@@ -272,6 +271,11 @@ module Facter
 
     def logger
       @logger ||= Log.new(self)
+    end
+
+    def init_cli_options(options)
+      options = options.map { |(k, v)| [k.to_sym, v] }.to_h
+      Facter::Options.init_from_cli(options, args)
     end
 
     def add_fact_to_searched_facts(user_query, value)

--- a/lib/facter.rb
+++ b/lib/facter.rb
@@ -133,7 +133,6 @@ module Facter
       LegacyFacter.reset
       Options[:custom_dir] = []
       Options[:external_dir] = []
-      @logger = nil
       nil
     end
 

--- a/spec/custom_facts/core/execution_spec.rb
+++ b/spec/custom_facts/core/execution_spec.rb
@@ -5,7 +5,12 @@ require_relative '../../spec_helper_legacy'
 describe Facter::Core::Execution do
   subject(:execution) { Facter::Core::Execution }
 
+  let(:windows_impl) { instance_spy(Facter::Core::Execution::Windows) }
   let(:impl) { Facter::Core::Execution.impl }
+
+  before do
+    allow(Facter::Core::Execution::Windows).to receive(:new).and_return(windows_impl)
+  end
 
   it 'delegates #search_paths to the implementation' do
     expect(impl).to receive(:search_paths)
@@ -18,12 +23,12 @@ describe Facter::Core::Execution do
   end
 
   it 'delegates #absolute_path? to the implementation' do
-    expect(impl).to receive(:absolute_path?).with('waffles', nil)
+    expect(impl).to receive(:absolute_path?).with('waffles')
     execution.absolute_path?('waffles')
   end
 
   it 'delegates #absolute_path? with an optional platform to the implementation' do
-    expect(impl).to receive(:absolute_path?).with('waffles', :windows)
+    expect(windows_impl).to receive(:absolute_path?).with('waffles')
     execution.absolute_path?('waffles', :windows)
   end
 

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -120,8 +120,9 @@ describe Facter::Util::Resolution do
 
   describe 'evaluating' do
     it 'evaluates the block in the context of the given resolution' do
-      expect(resolution).to receive(:weight).with(5)
-      resolution.evaluate { weight(5) }
+      expect(resolution).to receive(:setcode).with('code')
+
+      resolution.evaluate { setcode('code') }
     end
 
     it 'raises a warning if the resolution is evaluated twice' do

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -208,10 +208,10 @@ describe Facter do
     describe '#search' do
       it 'sends call to Facter::Options' do
         allow(Facter::Options).to receive(:[]=)
-      	dirs = ['/dir1', '/dir2']
-      	Facter.search(*dirs)
+        dirs = ['/dir1', '/dir2']
+        Facter.search(*dirs)
 
-      	expect(Facter::Options).to have_received(:[]=).with(:custom_dir, dirs)
+        expect(Facter::Options).to have_received(:[]=).with(:custom_dir, dirs)
       end
     end
 
@@ -225,10 +225,10 @@ describe Facter do
     describe '#search_external' do
       it 'sends call to Facter::Options' do
         allow(Facter::Options).to receive(:[]=)
-      	dirs = ['/dir1', '/dir2']
-      	Facter.search_external(dirs)
+        dirs = ['/dir1', '/dir2']
+        Facter.search_external(dirs)
 
-      	expect(Facter::Options).to have_received(:[]=).with(:external_dir, dirs)
+        expect(Facter::Options).to have_received(:[]=).with(:external_dir, dirs)
       end
     end
 

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -33,7 +33,7 @@ describe Facter do
   end
 
   after do
-    Facter.reset
+    Facter.instance_variable_set(:@logger, nil)
   end
 
   def mock_fact_manager(method, return_value)

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -21,11 +21,11 @@ describe Facter do
     allow(config_reader_double).to receive(:ttls).and_return([])
     allow(config_reader_double).to receive(:block_list).and_return([])
 
-    allow(Facter::FactGroups).to receive(:instance).and_return(block_list_double)
+    allow(Facter::FactGroups).to receive(:new).and_return(block_list_double)
     allow(block_list_double).to receive(:blocked_facts).and_return([])
     allow(block_list_double).to receive(:block_list).and_return([])
 
-    Facter.instance_variable_set(:@logger, logger)
+    allow(Facter::Log).to receive(:new).and_return(logger)
     Facter.clear
     allow(Facter::SessionCache).to receive(:invalidate_all_caches)
     allow(Facter::FactManager).to receive(:instance).and_return(fact_manager_spy)
@@ -33,7 +33,7 @@ describe Facter do
   end
 
   after do
-    Facter.remove_instance_variable(:@logger)
+    Facter.reset
   end
 
   def mock_fact_manager(method, return_value)
@@ -101,7 +101,6 @@ describe Facter do
         expected_json_output = '{}'
         allow(Facter::Options).to receive(:[]).and_call_original
         allow(Facter::Options).to receive(:[]).with(:strict).and_return(true)
-        allow(OsDetector).to receive(:detect).and_return(:solaris)
 
         formatted_facts = Facter.to_user_output({}, *user_query)
 
@@ -208,10 +207,11 @@ describe Facter do
 
     describe '#search' do
       it 'sends call to Facter::Options' do
-        dirs = ['/dir1', '/dir2']
+        allow(Facter::Options).to receive(:[]=)
+      	dirs = ['/dir1', '/dir2']
+      	Facter.search(*dirs)
 
-        expect(Facter::Options).to receive(:[]=).with(:custom_dir, dirs)
-        Facter.search(*dirs)
+      	expect(Facter::Options).to have_received(:[]=).with(:custom_dir, dirs)
       end
     end
 
@@ -224,10 +224,11 @@ describe Facter do
 
     describe '#search_external' do
       it 'sends call to Facter::Options' do
-        dirs = ['/dir1', '/dir2']
-        expect(Facter::Options).to receive(:[]=).with(:external_dir, dirs)
+        allow(Facter::Options).to receive(:[]=)
+      	dirs = ['/dir1', '/dir2']
+      	Facter.search_external(dirs)
 
-        Facter.search_external(dirs)
+      	expect(Facter::Options).to have_received(:[]=).with(:external_dir, dirs)
       end
     end
 
@@ -314,8 +315,10 @@ describe Facter do
 
   describe '#debugging' do
     it 'sets log level to debug' do
-      expect(Facter::Options).to receive(:[]=).with(:debug, true)
+      allow(Facter::Options).to receive(:[]=)
       Facter.debugging(true)
+
+      expect(Facter::Options).to have_received(:[]=).with(:debug, true)
     end
   end
 

--- a/spec/facter/resolvers/utils/windows/network_utils_spec.rb
+++ b/spec/facter/resolvers/utils/windows/network_utils_spec.rb
@@ -34,9 +34,6 @@ describe NetworkUtils do
       let(:address) { double(FFI::MemoryPointer) }
       let(:error) { 0 }
 
-      before do
-      end
-
       it 'returns an address' do
         expect(NetworkUtils.address_to_string(addr)).to eql('10.123.0.2')
       end

--- a/spec/framework/core/fact/external/external_fact_manager_spec.rb
+++ b/spec/framework/core/fact/external/external_fact_manager_spec.rb
@@ -8,8 +8,6 @@ describe Facter::ExternalFactManager do
     let(:custom_fact_manager) { Facter::ExternalFactManager.new }
 
     before do
-      allow(LegacyFacter).to receive(:search)
-      allow(LegacyFacter).to receive(:search_external)
       allow(LegacyFacter).to receive(:value).with(custom_fact_name).and_return(custom_fact_value)
     end
 

--- a/spec/framework/core/fact_loaders/external_fact_loader_spec.rb
+++ b/spec/framework/core/fact_loaders/external_fact_loader_spec.rb
@@ -38,20 +38,6 @@ describe Facter::ExternalFactLoader do
         expect(external_fact_loader.custom_facts).to eq([])
       end
     end
-
-    context 'when it blocks custom facts' do
-      before do
-        allow(collection).to receive(:custom_facts).and_return([])
-      end
-
-      it 'does not load custom facts (does not call LegacyFacter.search)' do
-        allow(Facter::Options).to receive(:custom_dir?).and_return(false)
-        expect(LegacyFacter).not_to receive(:search)
-
-        external_fact_loader = Facter::ExternalFactLoader.new
-        external_fact_loader.custom_facts
-      end
-    end
   end
 
   describe '#external_facts' do
@@ -81,20 +67,6 @@ describe Facter::ExternalFactLoader do
       it 'return no external facts' do
         external_fact_loader = Facter::ExternalFactLoader.new
         expect(external_fact_loader.external_facts).to eq([])
-      end
-    end
-
-    context 'when it blocks external facts' do
-      before do
-        allow(collection).to receive(:external_facts).and_return([])
-      end
-
-      it 'does not load custom facts (does not call LegacyFacter.search_external)' do
-        allow(Facter::Options).to receive(:external_dir?).and_return(false)
-        expect(LegacyFacter).not_to receive(:search_external)
-
-        external_fact_loader = Facter::ExternalFactLoader.new
-        external_fact_loader.external_facts
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,14 @@ RSpec.configure do |config|
     # cause any verifying double instantiation for a class that does not
     # exist to raise, protecting against incorrectly spelt names.
     mocks.verify_doubled_constant_names = true
+
+    # This option forces the same argument and method existence checks that are
+    # performed for object_double are also performed on partial doubles.
+    # You should set this unless you have a good reason not to.
+    # It defaults to off only for backwards compatibility.
+
+    # TODO: (FACT-2420) - enable this when windows specs are refactored
+    # mocks.verify_partial_doubles = true
   end
 
   config.after do

--- a/spec/spec_helper_legacy.rb
+++ b/spec/spec_helper_legacy.rb
@@ -33,7 +33,6 @@ RSpec.configure do |config|
   config.before do
     # Ensure that we don't accidentally cache facts and environment
     # between test cases.
-    allow(LegacyFacter::Util::Loader).to receive(:load_all)
     LegacyFacter.clear
     LegacyFacter.clear_messages
 
@@ -44,7 +43,7 @@ RSpec.configure do |config|
 
   config.after do
     # Restore environment variables after execution of each test
-    @old_env.each_pair { |k, v| ENV[k] = v }
+    (@old_env || {}).each_pair { |k, v| ENV[k] = v }
     to_remove = ENV.keys.reject { |key| @old_env.include? key }
     to_remove.each { |key| ENV.delete key }
   end

--- a/spec/spec_helper_legacy.rb
+++ b/spec/spec_helper_legacy.rb
@@ -32,7 +32,8 @@ RSpec.configure do |config|
 
   config.before do
     # Ensure that we don't accidentally cache facts and environment
-    # between test cases.
+    # between test cases
+
     LegacyFacter.clear
     LegacyFacter.clear_messages
 
@@ -43,7 +44,7 @@ RSpec.configure do |config|
 
   config.after do
     # Restore environment variables after execution of each test
-    (@old_env || {}).each_pair { |k, v| ENV[k] = v }
+    @old_env.each_pair { |k, v| ENV[k] = v }
     to_remove = ENV.keys.reject { |key| @old_env.include? key }
     to_remove.each { |key| ENV.delete key }
   end


### PR DESCRIPTION
The Windows and FFI helper specs are mocking FFI classes and extensions which does not exists because we monkey patch `Kernel.require` to not load FFI stuff. Until that part is fixed we cannot enable `verify_partial_doubles`.
