### PR TITLE
(FACT-2531) Fix for tests/facts/validate_file_system_size_bytes.rb

### DIFF
--- a/lib/facts/debian/architecture.rb
+++ b/lib/facts/debian/architecture.rb
@@ -10,6 +10,7 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
           fact_value = 'amd64' if fact_value == 'x86_64'
+          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facts/linux/os/architecture.rb
+++ b/lib/facts/linux/os/architecture.rb
@@ -10,6 +10,8 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
 
+          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
+
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end
       end

--- a/lib/facts/rhel/os/release.rb
+++ b/lib/facts/rhel/os/release.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Facts
+  module Rhel
+    module Os
+      class Release
+        FACT_NAME = 'os.release'
+        ALIASES = %w[operatingsystemmajrelease operatingsystemrelease].freeze
+
+        def call_the_resolver
+          version = determine_release_version
+
+          return Facter::ResolvedFact.new(FACT_NAME, nil) unless version
+
+          [Facter::ResolvedFact.new(FACT_NAME, version),
+           Facter::ResolvedFact.new(ALIASES.first, version['major'], :legacy),
+           Facter::ResolvedFact.new(ALIASES.last, version['full'], :legacy)]
+        end
+
+        def determine_release_version
+          version = Facter::Resolvers::OsRelease.resolve(:version_id)
+          version ||= Facter::Resolvers::RedHatRelease.resolve(:version)
+
+          return unless version
+
+          versions = version.split('.')
+          fact_value = {}
+          fact_value['full'] = version
+          fact_value['major'] = versions[0]
+          fact_value['minor'] = versions[1].gsub(/^0([1-9])/, '\1') if versions[1]
+          fact_value
+        end
+      end
+    end
+  end
+end

--- a/lib/resolvers/aix/mountpoints.rb
+++ b/lib/resolvers/aix/mountpoints.rb
@@ -19,7 +19,7 @@ module Facter
             @fact_list[:mountpoints] = {}
             output = Facter::Core::Execution.execute('mount', logger: log)
             output.split("\n").map do |line|
-              next if line =~ /\snode\s|---|procfs|ahafs/
+              next if line =~ /node|---|procfs|ahafs/
 
               elem = line.split("\s")
 

--- a/lib/resolvers/mountpoints_resolver.rb
+++ b/lib/resolvers/mountpoints_resolver.rb
@@ -39,10 +39,10 @@ module Facter
               next if path =~ %r{^/(proc|sys)} && filesystem != 'tmpfs' || filesystem == 'autofs'
 
               stats = FilesystemHelper.read_mountpoint_stats(path)
-              size_bytes = stats.bytes_total
-              available_bytes = stats.bytes_available
+              size_bytes = stats.bytes_total.abs
+              available_bytes = stats.bytes_available.abs
 
-              used_bytes = stats.bytes_used
+              used_bytes = stats.bytes_used.abs
               total_bytes = used_bytes + available_bytes
               capacity = FilesystemHelper.compute_capacity(used_bytes, total_bytes)
 

--- a/lib/resolvers/processors_resolver.rb
+++ b/lib/resolvers/processors_resolver.rb
@@ -25,6 +25,7 @@ module Facter
             read_processors(cpuinfo_output) # + model names
 
             @fact_list[:physical_count] = @fact_list[:physical_processors].uniq.length
+            @fact_list[:physical_count] = physical_devices_count if @fact_list[:physical_count].zero?
             @fact_list[fact_name]
           end
 
@@ -50,6 +51,10 @@ module Facter
 
           def count_physical_processors(tokens)
             @fact_list[:physical_processors] << tokens.last.strip.to_i if tokens.first.strip == 'physical id'
+          end
+
+          def physical_devices_count
+            Dir.entries('/sys/devices/system/cpu').count { |dir| dir =~ /cpu[0-9]+$/ }
           end
         end
       end

--- a/spec/facter/facts/debian/os/architecture_spec.rb
+++ b/spec/facter/facts/debian/os/architecture_spec.rb
@@ -23,6 +23,26 @@ describe Facts::Debian::Os::Architecture do
       end
     end
 
+    context 'when os is 32-bit' do
+      let(:value) { 'i586' }
+      let(:fact_value) { 'i386' }
+
+      before do
+        allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
+      end
+
+      it 'calls Facter::Resolvers::Uname' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: fact_value),
+                          an_object_having_attributes(name: 'architecture', value: fact_value, type: :legacy))
+      end
+    end
+
     context 'when resolver returns x86_64' do
       let(:value) { 'x86_64' }
 

--- a/spec/facter/facts/linux/os/architecture_spec.rb
+++ b/spec/facter/facts/linux/os/architecture_spec.rb
@@ -4,21 +4,39 @@ describe Facts::Linux::Os::Architecture do
   describe '#call_the_resolver' do
     subject(:fact) { Facts::Linux::Os::Architecture.new }
 
-    let(:value) { 'x86_64' }
-
     before do
       allow(Facter::Resolvers::Uname).to receive(:resolve).with(:machine).and_return(value)
     end
 
-    it 'calls Facter::Resolvers::Uname' do
-      fact.call_the_resolver
-      expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+    context 'when os is 64-bit' do
+      let(:value) { 'x86_64' }
+
+      it 'calls Facter::Resolvers::Uname' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
+                          an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
+      end
     end
 
-    it 'returns architecture fact' do
-      expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
-        contain_exactly(an_object_having_attributes(name: 'os.architecture', value: value),
-                        an_object_having_attributes(name: 'architecture', value: value, type: :legacy))
+    context 'when os is 32-bit' do
+      let(:value) { 'i686' }
+      let(:fact_value) { 'i386' }
+
+      it 'calls Facter::Resolvers::Uname' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::Uname).to have_received(:resolve).with(:machine)
+      end
+
+      it 'returns architecture fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.architecture', value: fact_value),
+                          an_object_having_attributes(name: 'architecture', value: fact_value, type: :legacy))
+      end
     end
   end
 end

--- a/spec/facter/facts/rhel/os/release_spec.rb
+++ b/spec/facter/facts/rhel/os/release_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe Facts::Rhel::Os::Release do
+  describe '#call_the_resolver' do
+    subject(:fact) { Facts::Rhel::Os::Release.new }
+
+    before do
+      allow(Facter::Resolvers::OsRelease).to receive(:resolve).with(:version_id).and_return(value)
+    end
+
+    context 'when os is RedHat' do
+      let(:value) { '6.2' }
+      let(:release) { { 'full' => '6.2', 'major' => '6', 'minor' => '2' } }
+
+      it 'calls Facter::Resolvers::OsRelease with version_id' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+
+    context 'when os is Centos' do
+      let(:value) { nil }
+      let(:red_release) { '6.2' }
+      let(:release) { { 'full' => '6.2', 'major' => '6', 'minor' => '2' } }
+
+      before do
+        allow(Facter::Resolvers::RedHatRelease).to receive(:resolve).with(:version).and_return(red_release)
+      end
+
+      it 'calls Facter::Resolvers::OsRelease with version_id' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::OsRelease).to have_received(:resolve).with(:version_id)
+      end
+
+      it 'calls Facter::Resolvers::RedHatRelease with version' do
+        fact.call_the_resolver
+        expect(Facter::Resolvers::RedHatRelease).to have_received(:resolve).with(:version)
+      end
+
+      it 'returns operating system name fact' do
+        expect(fact.call_the_resolver).to be_an_instance_of(Array).and \
+          contain_exactly(an_object_having_attributes(name: 'os.release', value: release),
+                          an_object_having_attributes(name: 'operatingsystemmajrelease',
+                                                      value: release['major'], type: :legacy),
+                          an_object_having_attributes(name: 'operatingsystemrelease',
+                                                      value: release['full'], type: :legacy))
+      end
+    end
+  end
+end

--- a/spec/facter/resolvers/mountpoints_resolver_spec.rb
+++ b/spec/facter/resolvers/mountpoints_resolver_spec.rb
@@ -11,7 +11,7 @@ describe Facter::Resolvers::Linux::Mountpoints do
   let(:stat) do
     double(Sys::Filesystem::Stat,
            path: '/', base_type: nil, fragment_size: 4096, block_size: 4096, blocks: 113_879_332,
-           blocks_available: 16_596_603, blocks_free: 22_398_776)
+           blocks_available: -16_596_603, blocks_free: 22_398_776)
   end
 
   let(:fact) do

--- a/spec/facter/resolvers/processors_resolver_spec.rb
+++ b/spec/facter/resolvers/processors_resolver_spec.rb
@@ -8,7 +8,7 @@ describe Facter::Resolvers::Linux::Processors do
   end
   let(:physical_processors) { 1 }
 
-  context 'when cpuingo file is readable' do
+  context 'when cpuinfo file is readable' do
     before do
       allow(Facter::Util::FileHelper).to receive(:safe_readlines)
         .with('/proc/cpuinfo')
@@ -18,6 +18,39 @@ describe Facter::Resolvers::Linux::Processors do
     after do
       Facter::Resolvers::Linux::Processors.invalidate_cache
     end
+
+    it 'returns number of processors' do
+      result = Facter::Resolvers::Linux::Processors.resolve(:processors)
+
+      expect(result).to eq(processors)
+    end
+
+    it 'returns list of models' do
+      result = Facter::Resolvers::Linux::Processors.resolve(:models)
+
+      expect(result).to eq(models)
+    end
+
+    it 'returns number of physical processors' do
+      result = Facter::Resolvers::Linux::Processors.resolve(:physical_count)
+
+      expect(result).to eq(physical_processors)
+    end
+  end
+
+  context 'when cpuinfo file is readable but no physical id' do
+    before do
+      allow(Facter::Util::FileHelper).to receive(:safe_readlines)
+        .with('/proc/cpuinfo')
+        .and_return(load_fixture('cpuinfo_wo_physical_id').readlines)
+      allow(Dir).to receive(:entries).with('/sys/devices/system/cpu').and_return(%w[cpu0 cpu1 cpuindex])
+    end
+
+    after do
+      Facter::Resolvers::Linux::Processors.invalidate_cache
+    end
+
+    let(:physical_processors) { 2 }
 
     it 'returns number of processors' do
       result = Facter::Resolvers::Linux::Processors.resolve(:processors)

--- a/spec/fixtures/cpuinfo_wo_physical_id
+++ b/spec/fixtures/cpuinfo_wo_physical_id
@@ -1,0 +1,103 @@
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 79
+model name	: Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz
+stepping	: 1
+microcode	: 0xb00002e
+cpu MHz		: 2294.686
+cache size	: 46080 KB
+siblings	: 4
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 invpcid rtm rdseed adx smap xsaveopt arat flush_l1d arch_capabilities
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds
+bogomips	: 4589.37
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 43 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 79
+model name	: Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz
+stepping	: 1
+microcode	: 0xb00002e
+cpu MHz		: 2294.686
+cache size	: 46080 KB
+siblings	: 4
+core id		: 1
+cpu cores	: 4
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 invpcid rtm rdseed adx smap xsaveopt arat flush_l1d arch_capabilities
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds
+bogomips	: 4589.37
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 43 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 79
+model name	: Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz
+stepping	: 1
+microcode	: 0xb00002e
+cpu MHz		: 2294.686
+cache size	: 46080 KB
+siblings	: 4
+core id		: 2
+cpu cores	: 4
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 invpcid rtm rdseed adx smap xsaveopt arat flush_l1d arch_capabilities
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds
+bogomips	: 4589.37
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 43 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 79
+model name	: Intel(R) Xeon(R) CPU E5-2697 v4 @ 2.30GHz
+stepping	: 1
+microcode	: 0xb00002e
+cpu MHz		: 2294.686
+cache size	: 46080 KB
+siblings	: 4
+core id		: 3
+cpu cores	: 4
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 20
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 invpcid rtm rdseed adx smap xsaveopt arat flush_l1d arch_capabilities
+bugs		: cpu_meltdown spectre_v1 spectre_v2 spec_store_bypass l1tf mds
+bogomips	: 4589.37
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 43 bits physical, 48 bits virtual
+power management:

--- a/spec/fixtures/mount
+++ b/spec/fixtures/mount
@@ -1,4 +1,4 @@
-  node       mounted        mounted over    vfs       date        options
+node       mounted        mounted over    vfs       date        options
 -------- ---------------  ---------------  ------ ------------ ---------------
          /dev/hd4         /                jfs2   Mar 22 08:05 rw,log=/dev/hd8
          /dev/hd2         /usr             jfs2   Mar 22 08:05 rw,log=/dev/hd8


### PR DESCRIPTION
Description of the problem:
 - for linux mountpoints all values have to be positive
- architecture fact for 32-bit os must be i386
- for rhel os release fact must be split 6.2 => major 6, minor 2
- mountpoints for aix contains an additional wrong fact : "mounted"=>{:device=>"node", :filesystem=>"mounted", :options=>["options"]} 
- physical count for processors fact is 0 when "physical id" is not present in /proc/cpuinfo

Description of the fix:
- call abs method for mountpoints bytes facts
- force architecture value to 'i386' if it matches /i[3456]86|pentium/
- implement os.release for rhel
- improve mountpoints regex to exclude file's header
- when physical count for processors fact is 0, count subdirectories from /sys/devices/system/cpu, that contains cpu(number) in name

This PR solves: tests/facts/validate_file_system_size_bytes.rb  test for all oses that have mountpoints fact and os_processors_and_kernel test **for all** oses.