### PR TITLE
(maint) Update rubocop to 0.81

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,18 +1,25 @@
 ---
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.3
+
 require:
   - rubocop-performance
   - rubocop-rspec
 
-Documentation:
-  Enabled: false
-
-Style/TrivialAccessors:
-  AllowDSLWriters: true
-
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
+
+Lint/RescueException:
+  Exclude:
+    - 'lib/custom_facts/util/parser.rb'
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
 
 Metrics/MethodLength:
   Max: 20
@@ -33,10 +40,6 @@ Metrics/BlockLength:
   Exclude:
     - !ruby/regexp /(?:(?!.+_spec.rb).)*$/
 
-Style/ClassVars:
-  Exclude:
-    - !ruby/regexp /(?:(?!.+_resolver.rb).)*$/
-
 Naming/ClassAndModuleCamelCase:
   Exclude:
     - 'spec/mocks/**/*'
@@ -54,21 +57,6 @@ Metrics/AbcSize:
     - 'lib/custom_facts/core/execution/base.rb'
     - 'lib/custom_facts/core/resolvable.rb'
 
-Style/FrozenStringLiteralComment:
-  Exclude:
-    - 'spec/custom_facts/util/normalization_spec.rb'
-    - 'spec/custom_facts/shared_contexts/platform.rb'
-    - 'spec/custom_facts/core/execution/windows_spec.rb'
-    - 'spec/custom_facts/core/execution/posix_spec.rb'
-    - 'lib/custom_facts/util/resolution.rb'
-    - 'lib/custom_facts/core/execution/windows.rb'
-    - 'lib/custom_facts/core/execution/posix.rb'
-
-Style/CaseEquality:
-  Exclude:
-    - 'spec/custom_facts/util/confine_spec.rb'
-    - 'lib/custom_facts/util/confine.rb'
-
 Metrics/PerceivedComplexity:
   Exclude:
     - 'lib/custom_facts/util/values.rb'
@@ -84,10 +72,6 @@ Metrics/CyclomaticComplexity:
     - 'lib/custom_facts/core/execution/posix.rb'
     - 'lib/framework/detector/os_detector.rb'
 
-Lint/RescueException:
-  Exclude:
-    - 'lib/custom_facts/util/parser.rb'
-
 Metrics/ClassLength:
   Exclude:
     - 'lib/custom_facts/util/fact.rb'
@@ -96,24 +80,9 @@ Metrics/ClassLength:
     - 'lib/framework/core/options/option_store.rb'
     - 'lib/framework/cli/cli.rb'
 
-Style/DoubleNegation:
-  Exclude:
-    - 'lib/custom_facts/util/confine.rb'
-    - 'lib/custom_facts/util/confine.rb'
-    - 'lib/custom_facts/core/execution/windows.rb'
-    - 'lib/custom_facts/core/execution/posix.rb'
-
 Naming/AccessorMethodName:
   Exclude:
     - 'lib/custom_facts/core/suitable.rb'
-
-Style/StderrPuts:
-  Exclude:
-    - 'lib/custom_facts/core/logging.rb'
-
-Style/ModuleFunction:
-  Exclude:
-    - 'lib/custom_facts/core/logging.rb'
 
 Naming/MethodName:
   Exclude:
@@ -122,14 +91,6 @@ Naming/MethodName:
 Naming/PredicateName:
   Exclude:
     - 'lib/custom_facts/core/suitable.rb'
-
-Style/MethodMissingSuper:
-  Exclude:
-    - 'lib/facter.rb'
-
-Style/MissingRespondToMissing:
-  Exclude:
-    - 'lib/facter.rb'
 
 Naming/FileName:
   Exclude:
@@ -144,3 +105,60 @@ RSpec/DescribedClass:
 
 RSpec/NestedGroups:
   Max: 5
+
+Style/Documentation:
+  Enabled: false
+
+Style/ClassVars:
+  Exclude:
+    - !ruby/regexp /(?:(?!.+_resolver.rb).)*$/
+
+Style/FrozenStringLiteralComment:
+  Exclude:
+    - 'spec/custom_facts/util/normalization_spec.rb'
+    - 'spec/custom_facts/shared_contexts/platform.rb'
+    - 'spec/custom_facts/core/execution/windows_spec.rb'
+    - 'spec/custom_facts/core/execution/posix_spec.rb'
+    - 'lib/custom_facts/util/resolution.rb'
+    - 'lib/custom_facts/core/execution/windows.rb'
+    - 'lib/custom_facts/core/execution/posix.rb'
+
+Style/TrivialAccessors:
+  AllowDSLWriters: true
+
+Style/CaseEquality:
+  Exclude:
+    - 'spec/custom_facts/util/confine_spec.rb'
+    - 'lib/custom_facts/util/confine.rb'
+
+Style/DoubleNegation:
+  Exclude:
+    - 'lib/custom_facts/util/confine.rb'
+    - 'lib/custom_facts/util/confine.rb'
+    - 'lib/custom_facts/core/execution/windows.rb'
+    - 'lib/custom_facts/core/execution/posix.rb'
+
+Style/MethodMissingSuper:
+  Exclude:
+    - 'lib/facter.rb'
+
+Style/MissingRespondToMissing:
+  Exclude:
+    - 'lib/facter.rb'
+
+Style/StderrPuts:
+  Exclude:
+    - 'lib/custom_facts/core/logging.rb'
+
+Style/ModuleFunction:
+  Exclude:
+    - 'lib/custom_facts/core/logging.rb'
+
+Style/HashEachMethods:
+  Enabled: false  # not implemted in ruby 2.3
+
+Style/HashTransformKeys:
+  Enabled: false  # not implemted in ruby 2.3
+
+Style/HashTransformValues:
+  Enabled: false  # not implemted in ruby 2.3

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8.23'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.74.0'
+  spec.add_development_dependency 'rubocop', '~> 0.81.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.38'
   spec.add_development_dependency 'sys-filesystem', '~> 1.3'

--- a/lib/resolvers/macosx/swap_memory_resolver.rb
+++ b/lib/resolvers/macosx/swap_memory_resolver.rb
@@ -33,7 +33,7 @@ module Facter
           end
 
           def compute_capacity(used, total)
-            format('%.2f', (used / total.to_f * 100)) + '%'
+            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
           end
         end
       end

--- a/lib/resolvers/macosx/system_memory_resolver.rb
+++ b/lib/resolvers/macosx/system_memory_resolver.rb
@@ -36,7 +36,7 @@ module Facter
           end
 
           def compute_capacity(used, total)
-            format('%.2f', (used / total.to_f * 100)) + '%'
+            "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
           end
         end
       end

--- a/lib/resolvers/utils/filesystem_helper.rb
+++ b/lib/resolvers/utils/filesystem_helper.rb
@@ -20,7 +20,7 @@ module Facter
         if used == total
           '100%'
         elsif used.positive?
-          "#{format('%.2f', 100.0 * used.to_f / total.to_f)}%"
+          "#{format('%<value>.2f', value: (used / total.to_f * 100))}%"
         else
           '0%'
         end

--- a/spec/facter/facter_spec.rb
+++ b/spec/facter/facter_spec.rb
@@ -147,10 +147,7 @@ describe Facter do
     it 'can be interpolated' do
       mock_fact_manager(:resolve_facts, [os_fact])
       mock_collection(:value, 'Ubuntu')
-
-      # rubocop:disable Style/UnneededInterpolation
-      expect("#{Facter.fact('os.name')}").to eq('Ubuntu')
-      # rubocop:enable Style/UnneededInterpolation
+      expect("#{Facter.fact('os.name')}-test").to eq('Ubuntu-test')
     end
 
     it 'returns no value' do

--- a/spec/facter/model/resolved_fact_spec.rb
+++ b/spec/facter/model/resolved_fact_spec.rb
@@ -24,15 +24,13 @@ describe Facter::ResolvedFact do
       expect(resolved_fact.core?).to be(true)
     end
 
-    # rubocop:disable Style/UnneededInterpolation
     it 'can be interpolated' do
-      expect("#{resolved_fact}").to eq('fact_value')
+      expect("#{resolved_fact}-test").to eq('fact_value-test')
     end
 
     it 'interpolation of nil value will be empty string' do
       resolved = Facter::ResolvedFact.new('fact_name', nil)
-      expect("#{resolved}").to eq('')
+      expect("#{resolved}-test").to eq('-test')
     end
-    # rubocop:enable Style/UnneededInterpolation
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ require 'fileutils'
 
 require_relative '../lib/resolvers/base_resolver'
 
-Dir[ROOT_DIR.join('spec/mocks/*.rb')].each { |file| require file }
+Dir[ROOT_DIR.join('spec/mocks/*.rb')].sort.each { |file| require file }
 
 require "#{ROOT_DIR}/lib/facter"
 require "#{ROOT_DIR}/lib/framework/cli/cli"


### PR DESCRIPTION
This is the last rubocop version that can run checks for ruby 2.3

- added new cops in .rubocop.yml
- group cops per category
- fix new offenses
- enforce checks to run for ruby 2.3