### PR TITLE
(FACT-2533) Fix for tests/facts/partitions.rb

### DIFF
--- a/lib/resolvers/partitions.rb
+++ b/lib/resolvers/partitions.rb
@@ -95,7 +95,9 @@ module Facter
         def execute_and_extract_blkid_info
           stdout = Facter::Core::Execution.execute('blkid', logger: log)
           output_hash = Hash[*stdout.split(/^([^:]+):/)[1..-1]]
-          output_hash.each { |key, value| output_hash[key] = Hash[*value.delete('"').chomp.split(/ ([^= ]+)=/)[1..-1]] }
+          output_hash.each do |key, value|
+            output_hash[key] = Hash[*value.delete('"').chomp.rstrip.split(/ ([^= ]+)=/)[1..-1]]
+          end
         end
 
         def browse_subdirectories(path)

--- a/spec/facter/resolvers/partitions_spec.rb
+++ b/spec/facter/resolvers/partitions_spec.rb
@@ -51,7 +51,8 @@ describe Facter::Resolvers::Partitions do
       context 'when device size files are readable' do
         let(:partitions) do
           { '/dev/sda1' => { filesystem: 'ext3', label: '/boot', size: '117.00 KiB',
-                             size_bytes: 119_808, uuid: '88077904-4fd4-476f-9af2-0f7a806ca25e' },
+                             size_bytes: 119_808, uuid: '88077904-4fd4-476f-9af2-0f7a806ca25e',
+                             partuuid: '00061fe0-01' },
             '/dev/sda2' => { size: '98.25 MiB', size_bytes: 103_021_056 } }
         end
 
@@ -63,7 +64,7 @@ describe Facter::Resolvers::Partitions do
       context 'when device size files are not readable' do
         let(:partitions_with_no_sizes) do
           { '/dev/sda1' => { filesystem: 'ext3', label: '/boot', size: '0 bytes',
-                             size_bytes: 0, uuid: '88077904-4fd4-476f-9af2-0f7a806ca25e' },
+                             size_bytes: 0, uuid: '88077904-4fd4-476f-9af2-0f7a806ca25e', partuuid: '00061fe0-01' },
             '/dev/sda2' => { size: '0 bytes', size_bytes: 0 } }
         end
 

--- a/spec/fixtures/blkid_output
+++ b/spec/fixtures/blkid_output
@@ -1,6 +1,6 @@
 /dev/mapper/VolGroup00-LogVol01: TYPE="swap"
 /dev/mapper/VolGroup00-LogVol00: UUID="1bd8643b-483a-4fdc-adcd-c586384919a8" TYPE="ext3"
-/dev/sda1: LABEL="/boot" UUID="88077904-4fd4-476f-9af2-0f7a806ca25e" TYPE="ext3" SEC_TYPE="ext2"
+/dev/sda1: LABEL="/boot" UUID="88077904-4fd4-476f-9af2-0f7a806ca25e" TYPE="ext3" SEC_TYPE="ext2" PARTUUID="00061fe0-01 "
 /dev/hdc: LABEL="VMware Tools" TYPE="iso9660"
 /dev/VolGroup00/LogVol00: UUID="1bd8643b-483a-4fdc-adcd-c586384919a8" TYPE="ext3"
 /dev/VolGroup00/LogVol01: TYPE="swap"


### PR DESCRIPTION
Description of the problem: when retrieving partuuid fact for partitions there is an extra space in it's value
Description of the fix: remove extra space from partuuid value