### PR TITLE
(maint) Fix networking linux for non-root users

### DIFF
--- a/lib/resolvers/networking_linux_resolver.rb
+++ b/lib/resolvers/networking_linux_resolver.rb
@@ -61,7 +61,7 @@ module Facter
 
         def retrieve_from_other_directories(interface_name)
           DIRS.each do |dir|
-            next unless Dir.exist?(dir)
+            next unless File.readable?(dir)
 
             lease_files = Dir.entries(dir).select { |file| file =~ /dhclient.*\.lease/ }
             next if lease_files.empty?
@@ -73,7 +73,7 @@ module Facter
               return content.match(/dhcp-server-identifier ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/)[1]
             end
           end
-          return unless Dir.exist?('/var/lib/NetworkManager/')
+          return unless File.readable?('/var/lib/NetworkManager/')
 
           search_internal_leases(interface_name)
         end

--- a/spec/facter/resolvers/networking_linux_resolver_spec.rb
+++ b/spec/facter/resolvers/networking_linux_resolver_spec.rb
@@ -23,7 +23,7 @@ describe Facter::Resolvers::NetworkingLinux do
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/run/systemd/netif/leases/2', nil).and_return(load_fixture('dhcp_lease').read)
 
-      allow(Dir).to receive(:exist?).with('/var/lib/dhclient/').and_return(true)
+      allow(File).to receive(:readable?).with('/var/lib/dhclient/').and_return(true)
       allow(Dir).to receive(:entries).with('/var/lib/dhclient/').and_return(['dhclient.lo.leases', 'dhclient.leases'])
       allow(Facter::Util::FileHelper).to receive(:safe_read)
         .with('/var/lib/dhclient/dhclient.lo.leases', nil).and_return(load_fixture('dhclient_lease').read)


### PR DESCRIPTION
Description of the problem:
- when running facter as a non-root user facter will throw an exception because some directories are not readable by current user

Description of the fix:
- verify that directories that are about to be checked are readable by current user
