### PR TITLE
(FACT-2525) Fix for tests/options/color.rb

### DIFF
--- a/.github/workflows/acceptance_tests.yml
+++ b/.github/workflows/acceptance_tests.yml
@@ -57,5 +57,11 @@ jobs:
           sudo chmod a-w /home/runner /usr/share &&
           sudo chmod -R a-w /usr/share/rust /home/runner/.config /home/linuxbrew
 
+      - name: Instal dhclient
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt install dhcpcd5
+          sudo dhclient
+
       - name: Run acceptance tests
         run: sudo -E "PATH=$PATH" ruby facter_4/.github/actions/presuite.rb

--- a/lib/framework/core/options/option_store.rb
+++ b/lib/framework/core/options/option_store.rb
@@ -23,6 +23,7 @@ module Facter
     @user_query = []
     @block_list = {}
     @fact_groups = {}
+    @color = false
 
     class << self
       attr_reader :debug, :verbose, :log_level, :show_legacy, :trace, :ruby,
@@ -31,7 +32,7 @@ module Facter
       attr_accessor :config, :user_query, :strict, :json, :haml, :external_facts,
                     :cache, :yaml, :puppet, :ttls, :block, :cli, :config_file_custom_dir,
                     :config_file_external_dir, :default_external_dir, :fact_groups,
-                    :block_list
+                    :block_list, :color
 
       attr_writer :external_dir
 

--- a/lib/framework/logging/logger.rb
+++ b/lib/framework/logging/logger.rb
@@ -4,6 +4,11 @@ require 'logger'
 
 module Facter
   RED = 31
+  GREEN = 32
+  YELLOW = 33
+  CYAN = 36
+
+
   DEFAULT_LOG_LEVEL = :warn
 
   class Log
@@ -73,25 +78,31 @@ module Facter
       elsif @@message_callback
         @@message_callback.call(:debug, msg)
       else
+        msg = colorize(msg, CYAN) if Options[:color]
         @@logger.debug(@class_name + ' - ' + msg)
       end
     end
 
     def info(msg)
+      msg = colorize(msg, GREEN) if Options[:color]
       @@logger.info(@class_name + ' - ' + msg)
     end
 
     def warn(msg)
+      msg = colorize(msg, YELLOW) if Options[:color]
+
       @@logger.warn(@class_name + ' - ' + msg)
     end
 
     def error(msg, colorize = false)
       @@has_errors = true
-      msg = colorize(msg, RED) if colorize && !OsDetector.instance.identifier.eql?(:windows)
+      msg = colorize(msg, RED) if colorize || Options[:color]
       @@logger.error(@class_name + ' - ' + msg)
     end
 
     def colorize(msg, color)
+      return msg if OsDetector.instance.identifier.eql?(:windows)
+
       "\e[#{color}m#{msg}\e[0m"
     end
 

--- a/lib/framework/logging/logger.rb
+++ b/lib/framework/logging/logger.rb
@@ -103,7 +103,7 @@ module Facter
     def colorize(msg, color)
       return msg if OsDetector.instance.identifier.eql?(:windows)
 
-      "\e[#{color}m#{msg}\e[0m"
+      "\e[0;#{color}m#{msg}\e[0m"
     end
 
     private

--- a/lib/framework/logging/logger.rb
+++ b/lib/framework/logging/logger.rb
@@ -8,7 +8,6 @@ module Facter
   YELLOW = 33
   CYAN = 36
 
-
   DEFAULT_LOG_LEVEL = :warn
 
   class Log
@@ -74,7 +73,7 @@ module Facter
 
       if msg.nil? || msg.empty?
         invoker = caller(1..1).first.slice(/.*:\d+/)
-        self.warn "#{self.class}#debug invoked with invalid message #{msg.inspect}:#{msg.class} at #{invoker}"
+        empty_message_error(msg, invoker)
       elsif @@message_callback
         @@message_callback.call(:debug, msg)
       else
@@ -112,6 +111,10 @@ module Facter
       return true unless Facter.respond_to?(:debugging?)
 
       Facter.debugging?
+    end
+
+    def empty_message_error(msg, invoker)
+      self.warn "#{self.class}#debug invoked with invalid message #{msg.inspect}:#{msg.class} at #{invoker}"
     end
   end
 end

--- a/spec/framework/core/options/option_store_spec.rb
+++ b/spec/framework/core/options/option_store_spec.rb
@@ -34,7 +34,8 @@ describe Facter::OptionStore do
         user_query: [],
         verbose: false,
         config: nil,
-        cache: true
+        cache: true,
+        color: false
       )
     end
   end

--- a/spec/framework/logging/logger_spec.rb
+++ b/spec/framework/logging/logger_spec.rb
@@ -7,6 +7,7 @@ describe Logger do
 
   before do
     Facter::Log.class_variable_set(:@@logger, multi_logger_double)
+    Facter::Options[:color] = false
   end
 
   after do
@@ -80,6 +81,42 @@ describe Logger do
         expect(Facter).not_to have_received(:debugging?)
       end
     end
+
+    context 'when non Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:macosx)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print CYAN (36) debug message' do
+          log.debug('debug_message')
+
+          expect(multi_logger_double).to have_received(:debug).with("Class - \e[0;36mdebug_message\e[0m")
+        end
+      end
+    end
+
+    context 'when Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:windows)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print CYAN (36) debug message' do
+          log.debug('debug_message')
+
+          expect(multi_logger_double).to have_received(:debug).with('Class - debug_message')
+        end
+      end
+    end
   end
 
   describe '#info' do
@@ -87,6 +124,42 @@ describe Logger do
       log.info('info_message')
 
       expect(multi_logger_double).to have_received(:info).with('Class - info_message')
+    end
+
+    context 'when non Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:macosx)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print Green (32) info message' do
+          log.info('info_message')
+
+          expect(multi_logger_double).to have_received(:info).with("Class - \e[0;32minfo_message\e[0m")
+        end
+      end
+    end
+
+    context 'when Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:windows)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print Green (32) info message' do
+          log.info('info_message')
+
+          expect(multi_logger_double).to have_received(:info).with('Class - info_message')
+        end
+      end
     end
   end
 
@@ -96,6 +169,42 @@ describe Logger do
 
       expect(multi_logger_double).to have_received(:warn).with('Class - warn_message')
     end
+
+    context 'when non Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:macosx)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print Yellow (33) info message' do
+          log.warn('warn_message')
+
+          expect(multi_logger_double).to have_received(:warn).with("Class - \e[0;33mwarn_message\e[0m")
+        end
+      end
+    end
+
+    context 'when Windows OS' do
+      before do
+        allow(OsDetector.instance).to receive(:identifier).and_return(:windows)
+      end
+
+      context 'when --colorize option is enabled' do
+        before do
+          Facter::Options[:color] = true
+        end
+
+        it 'print Yellow (33) info message' do
+          log.warn('warn_message')
+
+          expect(multi_logger_double).to have_received(:warn).with('Class - warn_message')
+        end
+      end
+    end
   end
 
   describe '#error' do
@@ -104,7 +213,7 @@ describe Logger do
 
       log.error('error_message', true)
 
-      expect(multi_logger_double).to have_received(:error).with("Class - \e[31merror_message\e[0m")
+      expect(multi_logger_double).to have_received(:error).with("Class - \e[0;31merror_message\e[0m")
     end
 
     it 'writes error message not colorized on Windows' do

--- a/spec/framework/logging/logger_spec.rb
+++ b/spec/framework/logging/logger_spec.rb
@@ -110,7 +110,7 @@ describe Logger do
           Facter::Options[:color] = true
         end
 
-        it 'print CYAN (36) debug message' do
+        it 'print debug message' do
           log.debug('debug_message')
 
           expect(multi_logger_double).to have_received(:debug).with('Class - debug_message')
@@ -154,7 +154,7 @@ describe Logger do
           Facter::Options[:color] = true
         end
 
-        it 'print Green (32) info message' do
+        it 'print info message' do
           log.info('info_message')
 
           expect(multi_logger_double).to have_received(:info).with('Class - info_message')
@@ -198,7 +198,7 @@ describe Logger do
           Facter::Options[:color] = true
         end
 
-        it 'print Yellow (33) info message' do
+        it 'print warn message' do
           log.warn('warn_message')
 
           expect(multi_logger_double).to have_received(:warn).with('Class - warn_message')


### PR DESCRIPTION
Color option was missing, causing `facter --color` to fail.
The fix adds color option and uses it in Logger to print log messages in different colors, depending on the log level.