### PR TITLE
(FACT-2521) Fix for tests/external_facts/external_fact_overrides_custom_fact_with_10000_weight_or_less.rb

### DIFF
--- a/lib/custom_facts/util/collection.rb
+++ b/lib/custom_facts/util/collection.rb
@@ -95,7 +95,7 @@ module LegacyFacter
         return @external_facts unless @external_facts.nil?
 
         load_external_facts
-        external_facts = @facts.reject { |_k, v| v.options[:fact_type] }
+        external_facts = @facts.select { |_k, v| v.options[:fact_type] == :external }
         @external_facts = Facter::Utils.deep_copy(external_facts.keys)
       end
 

--- a/lib/custom_facts/util/directory_loader.rb
+++ b/lib/custom_facts/util/directory_loader.rb
@@ -64,7 +64,7 @@ module LegacyFacter
           elsif (data == {}) || data.nil?
             LegacyFacter.warn "Fact file #{file} was parsed but returned an empty data set"
           else
-            data.each { |p, v| collection.add(p, value: v) { has_weight(weight) } }
+            data.each { |p, v| collection.add(p, value: v, fact_type: :external) { has_weight(weight) } }
           end
         end
       end

--- a/lib/custom_facts/util/fact.rb
+++ b/lib/custom_facts/util/fact.rb
@@ -161,7 +161,7 @@ module Facter
       end
 
       def sort_by_weight(resolutions)
-        resolutions.sort { |a, b| b.weight <=> a.weight }
+        resolutions.sort { |a, b| b <=> a }
       end
 
       def find_first_real_value(resolutions)

--- a/lib/custom_facts/util/resolution.rb
+++ b/lib/custom_facts/util/resolution.rb
@@ -13,7 +13,7 @@ module Facter
   module Util
     class Resolution
       # @api private
-      attr_accessor :code
+      attr_accessor :code, :fact_type
       attr_writer :value
 
       extend Facter::Core::Execution
@@ -129,7 +129,28 @@ module Facter
         end
       end
 
+      # Comparation is done based on weight and fact type.
+      # The greatter the weight, the higher the priority.
+      # If weights are equal, we consider external facts greater than custom facts
+      def <=>(other)
+        return compare_equal_weights(other) if weight == other.weight
+        return 1 if weight > other.weight
+        return -1 if weight < other.weight
+      end
+
       private
+
+      # If the weights are equal, we consider external facts greater tan custom facts
+      def compare_equal_weights(other)
+        # Other is considered greater because self is custom fact and other is external
+        return -1 if fact_type == :custom && other.fact_type == :external
+
+        # Self is considered greater, because it is external fact and other is custom
+        return 1 if fact_type == :external && other.fact_type == :custom
+
+        # They are considered equal
+        0
+      end
 
       def resolve_value
         if @value

--- a/spec/custom_facts/util/collection_spec.rb
+++ b/spec/custom_facts/util/collection_spec.rb
@@ -4,7 +4,7 @@
 require_relative '../../spec_helper_legacy'
 
 describe LegacyFacter::Util::Collection do
-  let(:external_loader) { LegacyFacter::Util::NothingLoader.new }
+  let(:external_loader) { instance_spy(LegacyFacter::Util::NothingLoader) }
   let(:internal_loader) do
     load = LegacyFacter::Util::Loader.new
     allow(load).to receive(:load).and_return nil
@@ -398,6 +398,49 @@ describe LegacyFacter::Util::Collection do
 
       it 'loads the new fact' do
         expect(collection.custom_facts.first). to eq(:new_fact)
+      end
+    end
+  end
+
+  describe '#external_facts' do
+    before do
+      collection.add('my_external_fact', fact_type: :external) {}
+    end
+
+    context 'when external facts are loaded for the first time' do
+      it 'calls load on external_loader' do
+        collection.external_facts
+
+        expect(external_loader).to have_received(:load)
+      end
+
+      it 'return 1 fact' do
+        expect(collection.external_facts.size).to eq(1)
+      end
+
+      it 'returns external fact' do
+        expect(collection.external_facts.first).to eq(:my_external_fact)
+      end
+    end
+
+    context 'when external facts were already loaded' do
+      before do
+        collection.instance_variable_set(:@external_facts, [:my_external_fact])
+        collection.instance_variable_set(:@external_facts_loaded, false)
+      end
+
+      it 'doe not call load on external_loader' do
+        collection.external_facts
+
+        expect(external_loader).not_to have_received(:load)
+      end
+
+      it 'return 1 fact' do
+        expect(collection.external_facts.size).to eq(1)
+      end
+
+      it 'returns external fact' do
+        expect(collection.external_facts.first).to eq(:my_external_fact)
       end
     end
   end

--- a/spec/custom_facts/util/directory_loader_spec.rb
+++ b/spec/custom_facts/util/directory_loader_spec.rb
@@ -9,6 +9,7 @@ describe LegacyFacter::Util::DirectoryLoader do
   subject(:dir_loader) { LegacyFacter::Util::DirectoryLoader.new(tmpdir('directory_loader')) }
 
   let(:collection) { LegacyFacter::Util::Collection.new(double('internal loader'), dir_loader) }
+  let(:collection_double) { instance_spy(LegacyFacter::Util::Collection) }
 
   it 'makes the directory available' do
     expect(dir_loader.directory).to be_instance_of(String)
@@ -40,6 +41,15 @@ describe LegacyFacter::Util::DirectoryLoader do
       dir_loader.load(collection)
 
       expect(collection.value('f1')).to eq 'one'
+    end
+
+    it 'adds fact with external type to collection' do
+      data = { 'f1' => 'one' }
+      write_to_file('data.yaml', YAML.dump(data))
+
+      dir_loader.load(collection_double)
+
+      expect(collection_double).to have_received(:add).with('f1', value: 'one', fact_type: :external)
     end
 
     it "ignores files that begin with '.'" do

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -132,4 +132,65 @@ describe Facter::Util::Resolution do
       resolution.evaluate {}
     end
   end
+
+  describe '#<=>' do
+    let(:other_fact) { double(Facter::Util::Fact, name: :other_fact) }
+    let(:other_resolution) { Facter::Util::Resolution.new(:other_fact, other_fact) }
+
+    context 'when self has greater weight than other' do
+      before do
+        resolution.options(weight: 100)
+        other_resolution.options(weight: 99)
+      end
+
+      it 'return 1' do
+        expect(resolution <=> other_resolution).to eq(1)
+      end
+    end
+
+    context 'when self has lower weight than other' do
+      before do
+        resolution.options(weight: 99)
+        other_resolution.options(weight: 100)
+      end
+
+      it 'return -1' do
+        expect(resolution <=> other_resolution).to eq(-1)
+      end
+    end
+
+    context 'when self has equal weight to other' do
+      before do
+        resolution.options(weight: 100)
+        other_resolution.options(weight: 100)
+      end
+
+      it 'returns 0' do
+        expect(resolution <=> other_resolution).to eq(0)
+      end
+
+      context 'when self is custom and other is external' do
+        before do
+          resolution.options(fact_type: :external)
+          other_resolution.options(fact_type: :custom)
+        end
+
+        it 'returns 1' do
+          expect(resolution <=> other_resolution).to eq(1)
+        end
+      end
+
+      context 'when self is external and other is custom' do
+        before do
+          resolution.options(fact_type: :custom)
+          other_resolution.options(fact_type: :external)
+        end
+
+        it 'returns -1' do
+          expect(resolution <=> other_resolution).to eq(-1)
+        end
+      end
+    end
+  end
+
 end

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -134,7 +134,7 @@ describe Facter::Util::Resolution do
   end
 
   describe '#<=>' do
-    let(:other_fact) { double(Facter::Util::Fact, name: :other_fact) }
+    let(:other_fact) { instance_spy(Facter::Util::Fact, name: :other_fact) }
     let(:other_resolution) { Facter::Util::Resolution.new(:other_fact, other_fact) }
 
     context 'when self has greater weight than other' do

--- a/spec/custom_facts/util/resolution_spec.rb
+++ b/spec/custom_facts/util/resolution_spec.rb
@@ -192,5 +192,4 @@ describe Facter::Util::Resolution do
       end
     end
   end
-
 end


### PR DESCRIPTION
External facts with same weight as custom facts should have higher priority. 
The fix take into consideration fact_type when comparing resolutions if the weights are equal.