### PR TITLE
(FACT-2522) Fix for tests/external_facts/fact_directory_precedence.rb

### DIFF
--- a/lib/custom_facts/util/config.rb
+++ b/lib/custom_facts/util/config.rb
@@ -46,7 +46,7 @@ module LegacyFacter
                                                        '/etc/puppetlabs/facter/facts.d',
                                                        '/etc/facter/facts.d/',
                                                        '/opt/puppetlabs/facter/facts.d'
-                                                      ]
+                                                     ]
                                                    end
         elsif ENV['HOME']
           Facter::Options[:default_external_dir] =

--- a/lib/custom_facts/util/config.rb
+++ b/lib/custom_facts/util/config.rb
@@ -42,7 +42,11 @@ module LegacyFacter
           Facter::Options[:default_external_dir] = if windows_dir
                                                      [File.join(windows_dir, 'PuppetLabs', 'facter', 'facts.d')]
                                                    else
-                                                     ['/opt/puppetlabs/facter/facts.d']
+                                                     [
+                                                       '/etc/puppetlabs/facter/facts.d',
+                                                       '/etc/facter/facts.d/',
+                                                       '/opt/puppetlabs/facter/facts.d'
+                                                      ]
                                                    end
         elsif ENV['HOME']
           Facter::Options[:default_external_dir] =

--- a/spec/custom_facts/util/config_spec.rb
+++ b/spec/custom_facts/util/config_spec.rb
@@ -57,7 +57,11 @@ describe LegacyFacter::Util::Config do
       allow(LegacyFacter::Util::Config).to receive(:windows_data_dir).and_return(nil)
       LegacyFacter::Util::Config.setup_default_ext_facts_dirs
       expect(LegacyFacter::Util::Config.external_facts_dirs)
-        .to eq ['/opt/puppetlabs/facter/facts.d']
+        .to eq [
+          '/etc/puppetlabs/facter/facts.d',
+          '/etc/facter/facts.d/',
+          '/opt/puppetlabs/facter/facts.d'
+        ]
     end
 
     it 'returns the default value for windows 2008' do


### PR DESCRIPTION
Default directories for external facts were missing, the correct ones are
```
'/etc/puppetlabs/facter/facts.d'
'/etc/facter/facts.d/'
'/opt/puppetlabs/facter/facts.d'
```
The order is also important, as the first ones will be loaded first and will have higher priority.