### PR TITLE
(FACT-2523) Fix for tests/external_facts/non_root_users_default_external_fact_directory.rb

### DIFF
--- a/lib/custom_facts/util/config.rb
+++ b/lib/custom_facts/util/config.rb
@@ -50,7 +50,8 @@ module LegacyFacter
                                                    end
         elsif ENV['HOME']
           Facter::Options[:default_external_dir] =
-            [File.expand_path(File.join(ENV['HOME'], '.puppetlabs', 'opt', 'facter', 'facts.d'))]
+            [File.join(ENV['HOME'], '.facter', 'facts.d'),
+             File.join(ENV['HOME'], '.puppetlabs', 'opt', 'facter', 'facts.d')]
         else
           Facter::Options[:default_external_dir] = []
         end

--- a/spec/custom_facts/util/config_spec.rb
+++ b/spec/custom_facts/util/config_spec.rb
@@ -84,7 +84,8 @@ describe LegacyFacter::Util::Config do
       allow(LegacyFacter::Util::Root).to receive(:root?).and_return(false)
       LegacyFacter::Util::Config.setup_default_ext_facts_dirs
       expect(LegacyFacter::Util::Config.external_facts_dirs)
-        .to eq [File.expand_path(File.join('~', '.puppetlabs', 'opt', 'facter', 'facts.d'))]
+        .to eq [File.expand_path(File.join('~', '.facter', 'facts.d')),
+                File.expand_path(File.join('~', '.puppetlabs', 'opt', 'facter', 'facts.d'))]
     end
 
     it 'includes additional values when user appends to the list' do


### PR DESCRIPTION
If a non root user runs facter, default external fact locations should be relative to the HOME of the user.
The order of the default locations for non root users is important because it determines the precedence of loading.