### PR TITLE
(FACT-2633) Relax rubocop dependancy

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Ruby version
     strategy:
       matrix:
-        ruby: [ 2.3, 2.7, jruby ]
+        ruby: [ 2.4, 2.7, jruby ]
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout current PR

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 require:
   - rubocop-performance

--- a/agent/facter-ng.gemspec
+++ b/agent/facter-ng.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
                  Dir.glob('**/*')
                end
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '~> 2.4'
   spec.files.reject! do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/facter.gemspec
+++ b/facter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
                  Dir.glob('**/*')
                end
 
-  spec.required_ruby_version = '~> 2.3'
+  spec.required_ruby_version = '~> 2.4'
   spec.files.reject! do |f|
     f.match(%r{^(test|spec|features)/})
   end
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.81.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.5.2'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.38'
   spec.add_development_dependency 'sys-filesystem', '~> 1.3'
   spec.add_development_dependency 'yard', '~> 0.9'

--- a/lib/custom_facts/core/execution/base.rb
+++ b/lib/custom_facts/core/execution/base.rb
@@ -77,7 +77,7 @@ module Facter
 
         def builtin_command?(command)
           output, _status = Open3.capture2("type #{command}")
-          output.chomp =~ /builtin/ ? true : false
+          /builtin/.match?(output.chomp) ? true : false
         end
 
         def execute_command(command, on_fail, logger = nil)

--- a/lib/custom_facts/core/execution/posix.rb
+++ b/lib/custom_facts/core/execution/posix.rb
@@ -44,7 +44,7 @@ module Facter
 
           return unless exe && (expanded = which(exe))
 
-          expanded = "'#{expanded}'" if expanded =~ /\s/
+          expanded = "'#{expanded}'" if /\s/.match?(expanded)
           expanded << " #{args}" if args
 
           expanded

--- a/lib/custom_facts/core/execution/windows.rb
+++ b/lib/custom_facts/core/execution/windows.rb
@@ -52,7 +52,7 @@ module Facter
 
           return unless exe && (expanded = which(exe))
 
-          expanded = "\"#{expanded}\"" if expanded =~ /\s+/
+          expanded = "\"#{expanded}\"" if /\s+/.match?(expanded)
           expanded << " #{args}" if args
 
           expanded

--- a/lib/custom_facts/util/normalization.rb
+++ b/lib/custom_facts/util/normalization.rb
@@ -46,7 +46,7 @@ module LegacyFacter
       # @param value [String]
       # @return [void]
 
-      if RUBY_VERSION =~ /^1\.8/
+      if RUBY_VERSION.start_with?('1.8')
         require 'iconv'
 
         def normalize_string(value)

--- a/lib/facts/debian/architecture.rb
+++ b/lib/facts/debian/architecture.rb
@@ -10,7 +10,7 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
           fact_value = 'amd64' if fact_value == 'x86_64'
-          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
+          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facts/linux/os/architecture.rb
+++ b/lib/facts/linux/os/architecture.rb
@@ -10,7 +10,7 @@ module Facts
         def call_the_resolver
           fact_value = Facter::Resolvers::Uname.resolve(:machine)
 
-          fact_value = 'i386' if fact_value =~ /i[3456]86|pentium/
+          fact_value = 'i386' if /i[3456]86|pentium/.match?(fact_value)
 
           [Facter::ResolvedFact.new(FACT_NAME, fact_value), Facter::ResolvedFact.new(ALIASES, fact_value, :legacy)]
         end

--- a/lib/facts/windows/hypervisors/kvm.rb
+++ b/lib/facts/windows/hypervisors/kvm.rb
@@ -18,7 +18,7 @@ module Facts
           product_name = Facter::Resolvers::DMIComputerSystem.resolve(:name)
 
           (Facter::Resolvers::Virtualization.resolve(:virtual) == 'kvm' || Facter::Resolvers::NetKVM.resolve(:kvm)) &&
-            product_name != 'VirtualBox' && !product_name.match(/^Parallels/)
+            product_name != 'VirtualBox' && !product_name.start_with?('Parallels')
         end
 
         def discover_provider
@@ -26,9 +26,9 @@ module Facts
 
           return { google: true } if manufacturer == 'Google'
 
-          return { openstack: true } if Facter::Resolvers::DMIComputerSystem.resolve(:name) =~ /^OpenStack/
+          return { openstack: true } if Facter::Resolvers::DMIComputerSystem.resolve(:name).start_with?('OpenStack')
 
-          return { amazon: true } if manufacturer =~ /^Amazon/
+          return { amazon: true } if manufacturer.start_with?('Amazon')
         end
       end
     end

--- a/lib/facts/windows/hypervisors/xen.rb
+++ b/lib/facts/windows/hypervisors/xen.rb
@@ -15,7 +15,7 @@ module Facts
         private
 
         def hvm?
-          Facter::Resolvers::DMIComputerSystem.resolve(:name) =~ /^HVM/
+          Facter::Resolvers::DMIComputerSystem.resolve(:name).start_with?('HVM')
         end
       end
     end

--- a/lib/facts_utils/windows_release_finder.rb
+++ b/lib/facts_utils/windows_release_finder.rb
@@ -11,7 +11,7 @@ module Facter
         description = input[:description]
         kernel_version = input[:kernel_version]
 
-        if version =~ /10.0/
+        if /10.0/.match?(version)
           check_version_10(consumerrel, kernel_version)
         else
           check_version_6(version, consumerrel) || check_version_5(version, consumerrel, description) || version
@@ -41,7 +41,7 @@ module Facter
       end
 
       def check_version_5(version, consumerrel, description)
-        return unless version =~ /5.2/
+        return unless /5.2/.match?(version)
         return 'XP' if consumerrel
 
         description == 'R2' ? '2003 R2' : '2003'

--- a/lib/framework/formatters/legacy_fact_formatter.rb
+++ b/lib/framework/formatters/legacy_fact_formatter.rb
@@ -85,7 +85,7 @@ module Facter
 
     def remove_comma_and_quation(output)
       @log.debug('Remove unnecessary comma and quotation marks on root facts')
-      output.split("\n").map! { |line| line =~ /^[\s]+/ ? line : line.gsub(/,$|\"/, '') }.join("\n")
+      output.split("\n").map! { |line| /^[\s]+/.match?(line) ? line : line.gsub(/,$|\"/, '') }.join("\n")
     end
   end
 end

--- a/lib/framework/formatters/yaml_fact_formatter.rb
+++ b/lib/framework/formatters/yaml_fact_formatter.rb
@@ -52,9 +52,9 @@ module Facter
     end
 
     def needs_quote?(value)
-      return false if value =~ /true|false/
+      return false if /true|false/.match?(value)
       return false if value[/^[0-9]+$/]
-      return true if value =~ /y|Y|yes|Yes|YES|n|N|no|No|NO|True|TRUE|False|FALSE|on|On|ON|off|Off|OFF|:/
+      return true if /y|Y|yes|Yes|YES|n|N|no|No|NO|True|TRUE|False|FALSE|on|On|ON|off|Off|OFF|:/.match?(value)
       return false if value[/[a-zA-Z]/]
       return false if value[/[0-9]+\.[0-9]+\./]
 

--- a/lib/framework/parsers/query_parser.rb
+++ b/lib/framework/parsers/query_parser.rb
@@ -91,7 +91,7 @@ module Facter
 
       def construct_filter_tokens(query_tokens, query_token_range)
         (query_tokens - query_tokens[query_token_range]).map do |token|
-          token =~ /^[0-9]+$/ ? token.to_i : token
+          /^[0-9]+$/.match?(token) ? token.to_i : token
         end
       end
     end

--- a/lib/framework/utils/utils.rb
+++ b/lib/framework/utils/utils.rb
@@ -18,7 +18,7 @@ module Facter
 
     def self.split_user_query(user_query)
       queries = user_query.split('.')
-      queries.map! { |query| query =~ /^[0-9]+$/ ? query.to_i : query }
+      queries.map! { |query| /^[0-9]+$/.match?(query) ? query.to_i : query }
     end
 
     def self.deep_stringify_keys(object)

--- a/lib/resolvers/aix/filesystem_resolver.rb
+++ b/lib/resolvers/aix/filesystem_resolver.rb
@@ -19,7 +19,7 @@ module Facter
             return if file_content.empty?
 
             file_content = file_content.map do |line|
-              next if line =~ /#|%/ # skip lines that are comments or defaultvfs line
+              next if /#|%/.match?(line) # skip lines that are comments or defaultvfs line
 
               line.split(' ').first
             end

--- a/lib/resolvers/aix/mountpoints.rb
+++ b/lib/resolvers/aix/mountpoints.rb
@@ -19,7 +19,7 @@ module Facter
             @fact_list[:mountpoints] = {}
             output = Facter::Core::Execution.execute('mount', logger: log)
             output.split("\n").map do |line|
-              next if line =~ /node|---|procfs|ahafs/
+              next if /node|---|procfs|ahafs/.match?(line)
 
               elem = line.split("\s")
 
@@ -34,7 +34,7 @@ module Facter
           def retrieve_sizes_for_mounts
             output = Facter::Core::Execution.execute('df -P', logger: log)
             output.split("\n").map do |line|
-              next if line =~ /Filesystem|-\s+-\s+-/
+              next if /Filesystem|-\s+-\s+-/.match?(line)
 
               mount_info = line.split("\s")
               mount_info[3] = translate_to_bytes(mount_info[3])

--- a/lib/resolvers/aix/partitions.rb
+++ b/lib/resolvers/aix/partitions.rb
@@ -53,14 +53,14 @@ module Facter
             }
             mount = info_hash['MOUNTPOINT']
             label = info_hash['LABEL']
-            part_info[:mount] = mount unless %r{N/A} =~ mount
-            part_info[:label] = label unless /None/ =~ label
+            part_info[:mount] = mount unless %r{N/A}.match?(mount)
+            part_info[:label] = label unless /None/.match?(label)
             part_info
           end
 
           def extract_info(lsl_content)
             lsl_content = lsl_content.strip.split("\n").map do |line|
-              next unless /PPs:|PP SIZE|TYPE:|LABEL:|MOUNT/ =~ line
+              next unless /PPs:|PP SIZE|TYPE:|LABEL:|MOUNT/.match?(line)
 
               line.split(/:|\s\s/).reject(&:empty?)
             end

--- a/lib/resolvers/disk_resolver.rb
+++ b/lib/resolvers/disk_resolver.rb
@@ -27,7 +27,7 @@ module Facter
                 next if result.empty?
 
                 # Linux always considers sectors to be 512 bytes long independently of the devices real block size.
-                value[key] = file =~ /size/ ? construct_size(value, result) : result
+                value[key] = /size/.match?(file) ? construct_size(value, result) : result
               end
             end
 

--- a/lib/resolvers/networking_linux_resolver.rb
+++ b/lib/resolvers/networking_linux_resolver.rb
@@ -68,7 +68,7 @@ module Facter
 
             lease_files.select do |file|
               content = Util::FileHelper.safe_read("#{dir}#{file}", nil)
-              next unless content =~ /interface.*#{interface_name}/
+              next unless /interface.*#{interface_name}/.match?(content)
 
               return content.match(/dhcp-server-identifier ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)/)[1]
             end

--- a/lib/resolvers/os_release_resolver.rb
+++ b/lib/resolvers/os_release_resolver.rb
@@ -49,7 +49,7 @@ module Facter
         end
 
         def pad_version_id
-          @fact_list[:version_id] = "#{@fact_list[:version_id]}.0" unless @fact_list[:version_id] =~ /\./
+          @fact_list[:version_id] = "#{@fact_list[:version_id]}.0" unless /\./.match?(@fact_list[:version_id])
         end
 
         def process_name

--- a/lib/resolvers/selinux_resolver.rb
+++ b/lib/resolvers/selinux_resolver.rb
@@ -26,7 +26,7 @@ module Facter
           mountpoint = ''
 
           output.each_line do |line|
-            next unless line =~ /selinuxfs/
+            next unless /selinuxfs/.match?(line)
 
             @fact_list[:enabled] = true
             mountpoint = line.split("\s")[1]
@@ -57,8 +57,8 @@ module Facter
           file_lines = Util::FileHelper.safe_readlines('/etc/selinux/config')
 
           file_lines.map do |line|
-            @fact_list[:config_mode] = line.split('=').last.strip if line =~ /^SELINUX=/
-            @fact_list[:config_policy] = line.split('=').last.strip if line =~ /^SELINUXTYPE=/
+            @fact_list[:config_mode] = line.split('=').last.strip if line.start_with?('SELINUX=')
+            @fact_list[:config_policy] = line.split('=').last.strip if line.start_with?('SELINUXTYPE=')
           end
 
           true unless file_lines.empty?

--- a/lib/resolvers/solaris/filesystems_resolver.rb
+++ b/lib/resolvers/solaris/filesystems_resolver.rb
@@ -19,7 +19,7 @@ module Facter
 
             file_content = Facter::Core::Execution.execute('/usr/sbin/sysdef', logger: log)
             files = file_content.split("\n").map do |line|
-              line.split('/').last if line =~ /^fs\.*/
+              line.split('/').last if /^fs\.*/.match?(line)
             end
 
             @fact_list[:file_systems] = files.compact.sort.join(',')

--- a/lib/resolvers/windows/virtualization_resolver.rb
+++ b/lib/resolvers/windows/virtualization_resolver.rb
@@ -39,11 +39,13 @@ module Facter
 
         def determine_hypervisor_by_manufacturer(comp)
           manufacturer = comp.Manufacturer
-          if comp.Model =~ /^Virtual Machine/ && manufacturer =~ /^Microsoft/
+          return 'physical' unless manufacturer
+
+          if comp.Model&.start_with?('Virtual Machine') && manufacturer.start_with?('Microsoft')
             'hyperv'
-          elsif manufacturer =~ /^Xen/
+          elsif manufacturer.start_with?('Xen')
             'xen'
-          elsif manufacturer =~ /^Amazon EC2/
+          elsif manufacturer.start_with?('Amazon EC2')
             'kvm'
           else
             'physical'


### PR DESCRIPTION
- Fix new cops offences
- Ruby 2.3 is not supported by newer versions of rubocop