### PR TITLE
(FACT-2636) Set external as fact_type for environment variable facts.

### DIFF
--- a/lib/custom_facts/util/loader.rb
+++ b/lib/custom_facts/util/loader.rb
@@ -141,7 +141,7 @@ module LegacyFacter
           # match it.
           next if fact && (env_name != fact)
 
-          LegacyFacter.add(Regexp.last_match(1)) do
+          LegacyFacter.add(Regexp.last_match(1), fact_type: :external) do
             has_weight 1_000_000
             setcode { value }
           end

--- a/spec/custom_facts/util/loader_spec.rb
+++ b/spec/custom_facts/util/loader_spec.rb
@@ -156,10 +156,11 @@ describe LegacyFacter::Util::Loader do
   describe 'when loading facts' do
     it 'loads values from the matching environment variable if one is present' do
       loader = loader_from(env: { 'facter_testing' => 'yayness' })
-
-      expect(LegacyFacter).to receive(:add).with('testing')
+      allow(LegacyFacter).to receive(:add)
 
       loader.load(:testing)
+
+      expect(LegacyFacter).to have_received(:add).with('testing', { fact_type: :external })
     end
 
     it 'loads any files in the search path with names matching the fact name' do


### PR DESCRIPTION
Environment variable external facts were missing `fact_type: :external` option, and because of this they were ignored when resolving facts. This is required since `Facter 4.0.22` as external facts are identified based on `fact_type ` option. 