### PR TITLE
Use proper encoding

### DIFF
--- a/lib/resolvers/macosx/system_profiler_resolver.rb
+++ b/lib/resolvers/macosx/system_profiler_resolver.rb
@@ -44,7 +44,7 @@ module Facter
           log.debug 'Executing command: system_profiler SPSoftwareDataType SPHardwareDataType'
           output = Facter::Core::Execution.execute(
             'system_profiler SPHardwareDataType SPSoftwareDataType', logger: log
-          )
+          ).force_encoding('UTF-8')
           @fact_list = output.scan(/.*:[ ].*$/).map { |e| e.strip.match(/(.*?): (.*)/).captures }.to_h
           normalize_factlist
 


### PR DESCRIPTION
Command `system_profiler SPHardwareDataType SPSoftwareDataType` outputs `UTF-8` data. For example, default value of `Computer Name` has a `—` symbol, which does not fit `ASCII`:

![IMAGE 2020-05-30 22:46:58](https://user-images.githubusercontent.com/5202503/83337856-78f90a00-a2c7-11ea-96f6-da27b251c00a.jpg)

Here is a working fix.

Also there is something wrong with error reporting, as it was impossible to debug it without monkey-patching the code. The error was `ArgumentError (invalid byte sequence in US-ASCII)`, but here is what it looked like when I was enabling `--debug`:

```
Failed on localhost:
  Report result contains an '_output' key. Catalog application may have printed extraneous output to stdout: [2020-05-30 22:39:35.087846 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/is_virtual.rb:19:in `hypervisor_name'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/is_virtual.rb:15:in `virtual?'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/is_virtual.rb:9:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:35.371754 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/boot_volume.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:35.587217 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/username.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:35.795937 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/secure_virtual_memory.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:36.010697 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/uptime.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:36.228285 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/processors.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:36.437533 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/model_identifier.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:36.646697 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/processor_speed.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:36.926248 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/kernel_version.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:37.136823 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/boot_mode.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:37.417493 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/l2_cache_per_core.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:37.629902 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/boot_rom_version.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:37.837276 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/smc_version.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:38.047245 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/system_version.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:38.255441 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/computer_name.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:38.466142 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/l3_cache.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:38.683651 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/serial_number.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:38.903868 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/processor_name.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:39.114070 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/memory.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:39.328468 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/hardware_uuid.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:39.541055 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/model_name.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
  [2020-05-30 22:39:39.751689 ] ERROR Facter::InternalFactManager - /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `scan'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:52:in `retrieve_system_profiler'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `block in post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `fetch'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/macosx/system_profiler_resolver.rb:38:in `post_resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:21:in `block in resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `synchronize'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/resolvers/base_resolver.rb:19:in `resolve'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/facts/macosx/system_profiler/cores.rb:11:in `call_the_resolver'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/core_fact.rb:12:in `create'
  /opt/puppetlabs/bolt/lib/ruby/gems/2.5.0/gems/facter-4.0.21/lib/framework/core/fact/internal/internal_fact_manager.rb:30:in `block (2 levels) in start_threads' 
```