### PR TITLE
(maint) Add FreeBSD disks and partitions facts

### DIFF
--- a/lib/facts/freebsd/disks.rb
+++ b/lib/facts/freebsd/disks.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    class Disks
+      FACT_NAME = 'disks'
+
+      def call_the_resolver
+        disks = Facter::Resolvers::Freebsd::Geom.resolve(:disks)
+
+        Facter::ResolvedFact.new(FACT_NAME, disks)
+      end
+    end
+  end
+end

--- a/lib/facts/freebsd/partitions.rb
+++ b/lib/facts/freebsd/partitions.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Facts
+  module Freebsd
+    class Partitions
+      FACT_NAME = 'partitions'
+
+      def call_the_resolver
+        partitions = Facter::Resolvers::Freebsd::Geom.resolve(:partitions)
+
+        Facter::ResolvedFact.new(FACT_NAME, partitions)
+      end
+    end
+  end
+end

--- a/lib/resolvers/freebsd/geom_resolver.rb
+++ b/lib/resolvers/freebsd/geom_resolver.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+module Facter
+  module Resolvers
+    module Freebsd
+      class Geom < BaseResolver
+        @semaphore = Mutex.new
+        @fact_list ||= {}
+
+        class << self
+          private
+
+          def post_resolve(fact_name)
+            @fact_list.fetch(fact_name) { read_facts(fact_name) }
+          end
+
+          def read_facts(fact_name)
+            require_relative 'ffi/ffi_helper'
+            require 'rexml/document'
+
+            read_disks
+            read_partitions
+
+            @fact_list[fact_name]
+          end
+
+          def read_disks
+            @fact_list[:disks] = {}
+
+            each_geom_class_provider('DISK') do |provider|
+              name = provider.get_text('./name').value
+
+              @fact_list[:disks][name] = %i[read_model read_serial_number read_size].map do |x|
+                send(x, provider)
+              end.inject(:merge)
+            end
+          end
+
+          def read_partitions
+            @fact_list[:partitions] = {}
+
+            each_geom_class_provider('PART') do |provider|
+              name = provider.get_text('./name').value
+
+              @fact_list[:partitions][name] = %i[read_partlabel read_partuuid read_size].map do |x|
+                send(x, provider)
+              end.inject(:merge)
+            end
+          end
+
+          def each_geom_class_provider(geom_class_name, &block)
+            REXML::XPath.each(geom_topology, "/mesh/class[name/text() = '#{geom_class_name}']/geom/provider", &block)
+          end
+
+          def read_size(provider)
+            res = {}
+            return res unless (mediasize = provider.get_text('mediasize'))
+
+            mediasize = Integer(mediasize.value)
+
+            res[:size_bytes] = mediasize
+            res[:size] = Facter::FactsUtils::UnitConverter.bytes_to_human_readable(mediasize)
+            res
+          end
+
+          def read_model(provider)
+            res = {}
+            return res unless (model = provider.get_text('./config/descr'))
+
+            res[:model] = model.value
+            res
+          end
+
+          def read_partlabel(provider)
+            res = {}
+            return res unless (rawuuid = provider.get_text('./config/label'))
+
+            res[:partlabel] = rawuuid.value
+            res
+          end
+
+          def read_partuuid(provider)
+            res = {}
+            return res unless (rawuuid = provider.get_text('./config/rawuuid'))
+
+            res[:partuuid] = rawuuid.value
+            res
+          end
+
+          def read_serial_number(provider)
+            res = {}
+            return res unless (serial_number = provider.get_text('./config/ident'))
+
+            res[:serial_number] = serial_number.value
+            res
+          end
+
+          def geom_topology
+            @geom_topology ||= REXML::Document.new(geom_confxml)
+          end
+
+          def geom_confxml
+            Facter::Freebsd::FfiHelper.sysctl_by_name(:string, 'kern.geom.confxml')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/disks_spec.rb
+++ b/spec/facter/facts/freebsd/disks_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Disks do
+  subject(:fact) { Facts::Freebsd::Disks.new }
+
+  let(:disk) do
+    {
+      'disks' => {
+        'sda' => {
+          'model' => 'Virtual disk',
+          'size' => '20.00 GiB',
+          'size_bytes' => 21_474_836_480,
+          'vendor' => 'VMware'
+        }
+      }
+    }
+  end
+
+  describe '#call_the_resolver' do
+    before do
+      allow(Facter::Resolvers::Freebsd::Geom).to receive(:resolve).with(:disks).and_return(disk)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::Disk' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::Geom).to have_received(:resolve).with(:disks)
+    end
+
+    it 'returns resolved fact with name disk and value' do
+      expect(fact.call_the_resolver)
+        .to be_an_instance_of(Facter::ResolvedFact)
+        .and have_attributes(name: 'disks', value: disk)
+    end
+  end
+end

--- a/spec/facter/facts/freebsd/partitions_spec.rb
+++ b/spec/facter/facts/freebsd/partitions_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe Facts::Freebsd::Partitions do
+  subject(:fact) { Facts::Freebsd::Partitions.new }
+
+  let(:partitions) do
+    {
+      'ada0p1' => {
+        'partlabel' => 'gptboot0',
+        'partuuid' => '503d3458-c135-11e8-bd11-7d7cd061b26f',
+        'size' => '512.00 KiB',
+        'size_bytes' => 524_288
+      }
+    }
+  end
+
+  describe '#call_the_resolver' do
+    before do
+      allow(Facter::Resolvers::Freebsd::Geom).to receive(:resolve).with(:partitions).and_return(partitions)
+    end
+
+    it 'calls Facter::Resolvers::Freebsd::Partitions' do
+      fact.call_the_resolver
+      expect(Facter::Resolvers::Freebsd::Geom).to have_received(:resolve).with(:partitions)
+    end
+
+    it 'returns resolved fact with name partitions and value' do
+      expect(fact.call_the_resolver)
+        .to be_an_instance_of(Facter::ResolvedFact)
+        .and have_attributes(name: 'partitions', value: partitions)
+    end
+  end
+end

--- a/spec/facter/resolvers/freebsd/geom_resolver_spec.rb
+++ b/spec/facter/resolvers/freebsd/geom_resolver_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe Facter::Resolvers::Freebsd::Geom do
+  describe '#resolve' do
+    subject(:resolver) { Facter::Resolvers::Freebsd::Geom }
+
+    before do
+      allow(Facter::Freebsd::FfiHelper).to receive(:sysctl_by_name)
+        .with(:string, 'kern.geom.confxml')
+        .and_return(load_fixture('kern.geom.confxml').read)
+    end
+
+    describe 'disks resolution' do
+      let(:expected_output) do
+        {
+          'ada0' => {
+            model: 'Samsung SSD 850 PRO 512GB',
+            serial_number: 'S250NXAG959927J',
+            size: '476.94 GiB',
+            size_bytes: 512_110_190_592
+          }
+        }
+      end
+
+      it 'returns disks fact' do
+        expect(resolver.resolve(:disks)).to eql(expected_output)
+      end
+    end
+
+    describe 'partitions resolution' do
+      let(:expected_output) do
+        {
+          'ada0p1' => {
+            partlabel: 'gptboot0',
+            partuuid: '503d3458-c135-11e8-bd11-7d7cd061b26f',
+            size: '512.00 KiB',
+            size_bytes: 524_288
+          },
+          'ada0p2' => {
+            partlabel: 'swap0',
+            partuuid: '5048d40d-c135-11e8-bd11-7d7cd061b26f',
+            size: '2.00 GiB',
+            size_bytes: 2_147_483_648
+          },
+          'ada0p3' => {
+            partlabel: 'zfs0',
+            partuuid: '504f1547-c135-11e8-bd11-7d7cd061b26f',
+            size: '474.94 GiB',
+            size_bytes: 509_961_306_112
+          }
+        }
+      end
+
+      it 'returns partitions fact' do
+        expect(resolver.resolve(:partitions)).to eql(expected_output)
+      end
+    end
+  end
+end

--- a/spec/fixtures/kern.geom.confxml
+++ b/spec/fixtures/kern.geom.confxml
@@ -1,0 +1,337 @@
+<mesh>
+  <class id="0xffffffff81b732b0">
+    <name>FD</name>
+  </class>
+  <class id="0xffffffff81aff518">
+    <name>RAID</name>
+  </class>
+  <class id="0xffffffff81afc368">
+    <name>DEV</name>
+    <geom id="0xfffff800170b3e00">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0p2.eli</name>
+      <rank>4</rank>
+	<consumer id="0xfffff80018274780">
+	  <geom ref="0xfffff800170b3e00"/>
+	  <provider ref="0xfffff800170b3a00"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff80003953700">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0p3.eli</name>
+      <rank>4</rank>
+	<consumer id="0xfffff800038cd700">
+	  <geom ref="0xfffff80003953700"/>
+	  <provider ref="0xfffff80003948700"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff80007e01e00">
+      <class ref="0xffffffff81afc368"/>
+      <name>gpt/gptboot0</name>
+      <rank>4</rank>
+	<consumer id="0xfffff80003a1cb00">
+	  <geom ref="0xfffff80007e01e00"/>
+	  <provider ref="0xfffff80007e01b00"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff80003a11100">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0p3</name>
+      <rank>3</rank>
+	<consumer id="0xfffff8000398b700">
+	  <geom ref="0xfffff80003a11100"/>
+	  <provider ref="0xfffff80003a11000"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff80003a11300">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0p2</name>
+      <rank>3</rank>
+	<consumer id="0xfffff8000398b800">
+	  <geom ref="0xfffff80003a11300"/>
+	  <provider ref="0xfffff80003a11200"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff80003a11900">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0p1</name>
+      <rank>3</rank>
+	<consumer id="0xfffff8000398b880">
+	  <geom ref="0xfffff80003a11900"/>
+	  <provider ref="0xfffff80003a11400"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+    <geom id="0xfffff800038d6e00">
+      <class ref="0xffffffff81afc368"/>
+      <name>ada0</name>
+      <rank>2</rank>
+	<consumer id="0xfffff8000398ba80">
+	  <geom ref="0xfffff800038d6e00"/>
+	  <provider ref="0xfffff80003a11b00"/>
+	  <mode>r0w0e0</mode>
+	</consumer>
+    </geom>
+  </class>
+  <class id="0xffffffff82a08f70">
+    <name>ELI</name>
+    <geom id="0xfffff800170e6c00">
+      <class ref="0xffffffff82a08f70"/>
+      <name>ada0p2.eli</name>
+      <rank>3</rank>
+      <config>
+	<KeysTotal>1</KeysTotal>
+	<KeysAllocated>1</KeysAllocated>
+	<Flags>ONETIME, W-DETACH, W-OPEN</Flags>
+	<Version>7</Version>
+	<Crypto>hardware</Crypto>
+	<KeyLength>128</KeyLength>
+	<EncryptionAlgorithm>AES-XTS</EncryptionAlgorithm>
+	<State>ACTIVE</State>
+      </config>
+	<consumer id="0xfffff80018274600">
+	  <geom ref="0xfffff800170e6c00"/>
+	  <provider ref="0xfffff80003a11200"/>
+	  <mode>r1w1e1</mode>
+	  <config>
+	  </config>
+	</consumer>
+	<provider id="0xfffff800170b3a00">
+	  <geom ref="0xfffff800170e6c00"/>
+	  <mode>r1w1e0</mode>
+	  <name>ada0p2.eli</name>
+	  <mediasize>2147483648</mediasize>
+	  <sectorsize>4096</sectorsize>
+	  <stripesize>0</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	  </config>
+	</provider>
+    </geom>
+    <geom id="0xfffff80003a11a00">
+      <class ref="0xffffffff82a08f70"/>
+      <name>ada0p3.eli</name>
+      <rank>3</rank>
+      <config>
+	<KeysTotal>119</KeysTotal>
+	<KeysAllocated>119</KeysAllocated>
+	<Flags>BOOT, GELIBOOT</Flags>
+	<UsedKey>0</UsedKey>
+	<Version>7</Version>
+	<Crypto>hardware</Crypto>
+	<KeyLength>256</KeyLength>
+	<EncryptionAlgorithm>AES-XTS</EncryptionAlgorithm>
+	<State>ACTIVE</State>
+      </config>
+	<consumer id="0xfffff8000398b600">
+	  <geom ref="0xfffff80003a11a00"/>
+	  <provider ref="0xfffff80003a11000"/>
+	  <mode>r1w1e1</mode>
+	  <config>
+	  </config>
+	</consumer>
+	<provider id="0xfffff80003948700">
+	  <geom ref="0xfffff80003a11a00"/>
+	  <mode>r1w1e1</mode>
+	  <name>ada0p3.eli</name>
+	  <mediasize>509961302016</mediasize>
+	  <sectorsize>4096</sectorsize>
+	  <stripesize>0</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	  </config>
+	</provider>
+    </geom>
+  </class>
+  <class id="0xffffffff81a7dc30">
+    <name>MD</name>
+  </class>
+  <class id="0xffffffff82802b28">
+    <name>ZFS::VDEV</name>
+    <geom id="0xfffff80003ba5a00">
+      <class ref="0xffffffff82802b28"/>
+      <name>zfs::vdev</name>
+      <rank>4</rank>
+	<consumer id="0xfffff8000500ee00">
+	  <geom ref="0xfffff80003ba5a00"/>
+	  <provider ref="0xfffff80003948700"/>
+	  <mode>r1w1e1</mode>
+	</consumer>
+    </geom>
+  </class>
+  <class id="0xffffffff82802650">
+    <name>ZFS::ZVOL</name>
+  </class>
+  <class id="0xffffffff81b613d8">
+    <name>SWAP</name>
+    <geom id="0xfffff80018b1d400">
+      <class ref="0xffffffff81b613d8"/>
+      <name>swap</name>
+      <rank>4</rank>
+	<consumer id="0xfffff80018275500">
+	  <geom ref="0xfffff80018b1d400"/>
+	  <provider ref="0xfffff800170b3a00"/>
+	  <mode>r1w1e0</mode>
+	</consumer>
+    </geom>
+  </class>
+  <class id="0xffffffff81afe340">
+    <name>PART</name>
+    <geom id="0xfffff80003a11800">
+      <class ref="0xffffffff81afe340"/>
+      <name>ada0</name>
+      <rank>2</rank>
+      <config>
+	<scheme>GPT</scheme>
+	<entries>128</entries>
+	<first>40</first>
+	<last>1000215175</last>
+	<fwsectors>63</fwsectors>
+	<fwheads>16</fwheads>
+	<state>OK</state>
+	<modified>false</modified>
+      </config>
+	<consumer id="0xfffff8000398ba00">
+	  <geom ref="0xfffff80003a11800"/>
+	  <provider ref="0xfffff80003a11b00"/>
+	  <mode>r2w2e4</mode>
+	  <config>
+	  </config>
+	</consumer>
+	<provider id="0xfffff80003a11000">
+	  <geom ref="0xfffff80003a11800"/>
+	  <mode>r1w1e1</mode>
+	  <name>ada0p3</name>
+	  <mediasize>509961306112</mediasize>
+	  <sectorsize>512</sectorsize>
+	  <stripesize>4096</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	    <start>4196352</start>
+	    <end>1000214527</end>
+	    <index>3</index>
+	    <type>freebsd-zfs</type>
+	    <offset>2148532224</offset>
+	    <length>509961306112</length>
+	    <label>zfs0</label>
+	    <rawtype>516e7cba-6ecf-11d6-8ff8-00022d09712b</rawtype>
+	    <rawuuid>504f1547-c135-11e8-bd11-7d7cd061b26f</rawuuid>
+	    <efimedia>HD(3,GPT,504f1547-c135-11e8-bd11-7d7cd061b26f,0x400800,0x3b5e0800)</efimedia>
+	  </config>
+	</provider>
+	<provider id="0xfffff80003a11200">
+	  <geom ref="0xfffff80003a11800"/>
+	  <mode>r1w1e1</mode>
+	  <name>ada0p2</name>
+	  <mediasize>2147483648</mediasize>
+	  <sectorsize>512</sectorsize>
+	  <stripesize>4096</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	    <start>2048</start>
+	    <end>4196351</end>
+	    <index>2</index>
+	    <type>freebsd-swap</type>
+	    <offset>1048576</offset>
+	    <length>2147483648</length>
+	    <label>swap0</label>
+	    <rawtype>516e7cb5-6ecf-11d6-8ff8-00022d09712b</rawtype>
+	    <rawuuid>5048d40d-c135-11e8-bd11-7d7cd061b26f</rawuuid>
+	    <efimedia>HD(2,GPT,5048d40d-c135-11e8-bd11-7d7cd061b26f,0x800,0x400000)</efimedia>
+	  </config>
+	</provider>
+	<provider id="0xfffff80003a11400">
+	  <geom ref="0xfffff80003a11800"/>
+	  <mode>r0w0e0</mode>
+	  <name>ada0p1</name>
+	  <mediasize>524288</mediasize>
+	  <sectorsize>512</sectorsize>
+	  <stripesize>4096</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	    <start>40</start>
+	    <end>1063</end>
+	    <index>1</index>
+	    <type>freebsd-boot</type>
+	    <offset>20480</offset>
+	    <length>524288</length>
+	    <label>gptboot0</label>
+	    <rawtype>83bd6b9d-7f41-11dc-be0b-001560b84f0f</rawtype>
+	    <rawuuid>503d3458-c135-11e8-bd11-7d7cd061b26f</rawuuid>
+	    <efimedia>HD(1,GPT,503d3458-c135-11e8-bd11-7d7cd061b26f,0x28,0x400)</efimedia>
+	  </config>
+	</provider>
+    </geom>
+  </class>
+  <class id="0xffffffff81afd290">
+    <name>LABEL</name>
+    <geom id="0xfffff80007e01c00">
+      <class ref="0xffffffff81afd290"/>
+      <name>ada0p1</name>
+      <rank>3</rank>
+      <config>
+      </config>
+	<consumer id="0xfffff8000398b780">
+	  <geom ref="0xfffff80007e01c00"/>
+	  <provider ref="0xfffff80003a11400"/>
+	  <mode>r0w0e0</mode>
+	  <config>
+	  </config>
+	</consumer>
+	<provider id="0xfffff80007e01b00">
+	  <geom ref="0xfffff80007e01c00"/>
+	  <mode>r0w0e0</mode>
+	  <name>gpt/gptboot0</name>
+	  <mediasize>524288</mediasize>
+	  <sectorsize>512</sectorsize>
+	  <stripesize>4096</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	    <index>0</index>
+	    <length>524288</length>
+	    <seclength>1024</seclength>
+	    <offset>0</offset>
+	    <secoffset>0</secoffset>
+	  </config>
+	</provider>
+    </geom>
+  </class>
+  <class id="0xffffffff81afd0c0">
+    <name>VFS</name>
+  </class>
+  <class id="0xffffffff81afc868">
+    <name>Flashmap</name>
+  </class>
+  <class id="0xffffffff81afc678">
+    <name>DISK</name>
+    <geom id="0xfffff80003a11c00">
+      <class ref="0xffffffff81afc678"/>
+      <name>ada0</name>
+      <rank>1</rank>
+      <config>
+      </config>
+	<provider id="0xfffff80003a11b00">
+	  <geom ref="0xfffff80003a11c00"/>
+	  <mode>r2w2e4</mode>
+	  <name>ada0</name>
+	  <mediasize>512110190592</mediasize>
+	  <sectorsize>512</sectorsize>
+	  <stripesize>4096</stripesize>
+	  <stripeoffset>0</stripeoffset>
+	  <config>
+	    <fwheads>16</fwheads>
+	    <fwsectors>63</fwsectors>
+	    <rotationrate>0</rotationrate>
+	    <ident>S250NXAG959927J</ident>
+	    <lunid>50025388400c2138</lunid>
+	    <descr>Samsung SSD 850 PRO 512GB</descr>
+	  </config>
+	</provider>
+    </geom>
+  </class>
+</mesh>


### PR DESCRIPTION
Storage on FreeBSD is managed by GEOM, which expose the current storage topology as an XML tree through a sysctl.  Get this XML tree to build relevant facts.
